### PR TITLE
Small fixes to Auto Farm script

### DIFF
--- a/control.lua
+++ b/control.lua
@@ -572,12 +572,29 @@ script.on_event(defines.events.on_rocket_launched, function(event)
                         local posy = -11
                         local rpos = event.rocket_silo.position
 						repeat
-							if game.surfaces['nauvis'].find_entity(farm.crop,{rpos.x + posx, (rpos.y - 15) + posy}) == nil then
-								game.surfaces['nauvis'].create_entity {name = farm.crop, position = {rpos.x + posx, (rpos.y - 15) + posy}, amount = output[rs.get_recipe().name]}
+							local ore_pos = {rpos.x + posx, (rpos.y - 15) + posy}
+							local resources = game.surfaces['nauvis'].find_entities_filtered{position = ore_pos, type='resource'}
+							local ore = nil
+							
+							for _, r in pairs (resources) do
+								if r.name == farm.crop then
+									if ore == nil then
+										ore = r
+									else -- Fix in case there were overlapping resources. Shouldn't happen any more
+										ore.amount = ore.amount + r.amount 
+										r.destroy()
+									end
+								else
+									r.destroy() -- Remove other resources, for example changing the recipe in the auto farm
+								end
+							end
+							
+							if ore == nil then
+								game.surfaces['nauvis'].create_entity {name = farm.crop, position = ore_pos, amount = output[rs.get_recipe().name]}
 							else
-								local ore = game.surfaces['nauvis'].find_entity(farm.crop,{rpos.x + posx, (rpos.y - 15) + posy})
 								ore.amount = ore.amount + output[rs.get_recipe().name]
 							end
+
                             --game.surfaces['nauvis'].create_entity {name = farm.crop .. '-fake', position = {rpos.x + posx, (rpos.y - 15) + posy}}
                             posx = posx + 1
                             if posx == 12 then
@@ -588,9 +605,11 @@ script.on_event(defines.events.on_rocket_launched, function(event)
                     end
                 end
             end
+			
             local rpos = event.rocket_silo.position
-            local harvesters = game.surfaces['nauvis'].find_entities_filtered {area = {{rpos.x - 11, (rpos.y - 15) - 11}, {rpos.x + 11, (rpos.y - 15) + 11}}, name = 'harvester'}
-            for _, har in pairs(harvesters) do
+            local harvesters = game.surfaces['nauvis'].find_entities_filtered {area = {{rpos.x - 11, (rpos.y - 15) - 11}, {rpos.x + 11, (rpos.y - 15) + 11}}, name = {'harvester', 'collector'}}
+            
+			for _, har in pairs(harvesters) do
                 har.update_connections()
             end
         end


### PR DESCRIPTION
Some small tweaks to the Auto Farm scripts:
- If there are multiple resource entities of the same type on the same tile, merge them together.
- If there are different resource entities on the tile from what we're planting, then remove them (when changing recipe in the auto farm, for example).
- Also reset collectors on the field, just like harvesters. Needed for bio samples.