### PR TITLE
Added missing locale key

### DIFF
--- a/locale/en/locale.cfg
+++ b/locale/en/locale.cfg
@@ -1795,6 +1795,9 @@ ctc=Generated in the neural crest during embryonic development. These Zipir gene
 
 [tile-name]
 
+[fuel-category-name]
+bio-container=Bio-containers
+
 [ore-name]
 ore-bioreserve=Bioreserve
 


### PR DESCRIPTION
Fuel category label for bio-containers missing from locale file, seen when mousing-over "Collector" building.