### PR TITLE
Update locale.cfg

### DIFF
--- a/locale/en/locale.cfg
+++ b/locale/en/locale.cfg
@@ -1908,7 +1908,7 @@ ore-bioreserve=Bioreserve
 [shortcut-name]
 auog-selector=Auog control device
 
-[fuel-category]
+[fuel-category-name]
 food=Food
 meat=Meat
 drill=Drill heads


### PR DESCRIPTION
Fixes #12  "Unknown key" error for fuel category in burner type buildings and recipes.