### PR TITLE
Rebalance of Navens to not require advanced circuits at Mk1

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -2,6 +2,7 @@
 Version: 1.9.9
 Date: ????
   Changes:
+    - Balanced Navens to not require advanced circuits at mk1
 ---------------------------------------------------------------------------------------------------
 Version: 1.9.8
 Date: 2020-11-14

--- a/prototypes/buildings/navens-culture-mk01.lua
+++ b/prototypes/buildings/navens-culture-mk01.lua
@@ -9,7 +9,7 @@ RECIPE {
         {"nexelit-plate", 20},
         {"duralumin", 35},
         {"steel-plate", 50},
-        {"advanced-circuit", 15},
+        {"electronic-circuit", 15},
         {"tin-plate", 50},
     },
     results = {

--- a/prototypes/recipes/recipes-navens.lua
+++ b/prototypes/recipes/recipes-navens.lua
@@ -31,7 +31,7 @@ RECIPE {
     ingredients = {
         {type = 'item', name = 'glass', amount = 2},
         {type = 'item', name = 'small-lamp', amount = 5},
-        {type = 'item', name = 'advanced-circuit', amount = 50},
+        {type = 'item', name = 'electronic-circuit', amount = 50},
         {type = 'item', name = 'red-wire', amount = 20},
     },
     results = {


### PR DESCRIPTION
In order to play on a map without the nonstandard ores (rocks, reserves, etc), one has to make rare earths through the Phadais pathway. As far as I can tell the Navens are the only blocker to this. Having Navens not require advanced circuits at mk1 should open a path to rare earth without having to mine any from the map.