### PR TITLE
Make unit-controller spawnable

### DIFF
--- a/prototypes/items/items.lua
+++ b/prototypes/items/items.lua
@@ -9535,7 +9535,7 @@ data:extend(
 		name = 'unit-controller',
 		icon = '__pyalienlifegraphics__/graphics/icons/carrot_on_a_stick.png',
 		icon_size = 64,
-		flags = {},
+		flags = {"spawnable", "only-in-cursor"},
 		subgroup = "tool",
 		order = "a",
 		stack_size = 1,


### PR DESCRIPTION
Factorio version 1.1.6 (latest as of now). Clicking on "Auog control device" on the toolbar does nothing (worked in earlier versions).

My guess is that they added this flag recently:
https://wiki.factorio.com/Types/ItemPrototypeFlags#.22spawnable.22

Weird thing: flag is not mentioned in https://lua-api.factorio.com/latest/Concepts.html#ItemPrototypeFlags, not sure why.

The Green Button works correctly with it (tested).

Also added `only-in-cursor` flag so controller doesn't needlessly clutter inventory, but that doesn't matter as much.