### PR TITLE
Stop caravans from destroying items on chest overflow

### DIFF
--- a/control.lua
+++ b/control.lua
@@ -1058,12 +1058,16 @@ script.on_event(
 					)
 					if outpostinventory ~= nil then
 						if caravanroutes[car].inventory.hasitem then
-							outpostinventory.insert(
+							local removedcount = outpostinventory.insert(
 								{name = caravanroutes[car].inventory.item, count = caravanroutes[car].inventory.stackamount}
 							)
-							caravanroutes[car].inventory.hasitem = false
-							caravanroutes[car].inventory.item = ""
-							caravanroutes[car].inventory.stackamount = 0
+							if removedcount == caravanroutes[car].inventory.stackamount then
+								caravanroutes[car].inventory.hasitem = false
+								caravanroutes[car].inventory.item = ""
+								caravanroutes[car].inventory.stackamount = 0
+							else
+								caravanroutes[car].inventory.stackamount = caravanroutes[car].inventory.stackamount - removedcount
+							end
 						else
 							local contents = outpostinventory.get_contents()
 							--log(serpent.block(outpostinventory))
@@ -1110,12 +1114,16 @@ script.on_event(
 					)
 					if outpostinventory ~= nil then
 						if caravanroutes[car].inventory.hasitem then
-							outpostinventory.insert(
+							local removedcount = outpostinventory.insert(
 								{name = caravanroutes[car].inventory.item, count = caravanroutes[car].inventory.stackamount}
 							)
-							caravanroutes[car].inventory.hasitem = false
-							caravanroutes[car].inventory.item = ""
-							caravanroutes[car].inventory.stackamount = 0
+							if removedcount == caravanroutes[car].inventory.stackamount then
+								caravanroutes[car].inventory.hasitem = false
+								caravanroutes[car].inventory.item = ""
+								caravanroutes[car].inventory.stackamount = 0
+							else
+								caravanroutes[car].inventory.stackamount = caravanroutes[car].inventory.stackamount - removedcount
+							end
 						else
 							local contents = outpostinventory.get_contents()
 							--log(serpent.block(outpostinventory))

--- a/scripts/caravan.lua
+++ b/scripts/caravan.lua
@@ -118,10 +118,14 @@ script.on_event(
             local outpostinventory = game.surfaces[caravanroutes[car].unit.surface.name].find_entity('outpost', caravanroutes[car].startpoint.pos).get_inventory(defines.inventory.chest)
             if outpostinventory ~= nil then
                 if caravanroutes[car].inventory.hasitem then
-                    outpostinventory.insert({name=caravanroutes[car].inventory.item, count=caravanroutes[car].inventory.stackamount})
-					caravanroutes[car].inventory.hasitem = false
-					caravanroutes[car].inventory.item = ''
-					caravanroutes[car].inventory.stackamount = 0
+                    local removedcount = outpostinventory.insert({name=caravanroutes[car].inventory.item, count=caravanroutes[car].inventory.stackamount})
+                    if removedcount == caravanroutes[car].inventory.stackamount then
+                        caravanroutes[car].inventory.hasitem = false
+                        caravanroutes[car].inventory.item = ''
+                        caravanroutes[car].inventory.stackamount = 0
+                    else
+                        caravanroutes[car].inventory.stackamount = caravanroutes[car].inventory.stackamount - removedcount
+                    end
                 else
                     local contents = outpostinventory.get_contents()
                     --log(serpent.block(outpostinventory))
@@ -155,10 +159,14 @@ script.on_event(
             local outpostinventory = game.surfaces[caravanroutes[car].unit.surface.name].find_entity('outpost', caravanroutes[car].endpoint.pos).get_inventory(defines.inventory.chest)
             if outpostinventory ~= nil then
                 if caravanroutes[car].inventory.hasitem then
-                    outpostinventory.insert({name=caravanroutes[car].inventory.item, count=caravanroutes[car].inventory.stackamount})
-					caravanroutes[car].inventory.hasitem = false
-					caravanroutes[car].inventory.item = ''
-					caravanroutes[car].inventory.stackamount = 0
+                    local removedcount = outpostinventory.insert({name=caravanroutes[car].inventory.item, count=caravanroutes[car].inventory.stackamount})
+                    if removedcount == caravanroutes[car].inventory.stackamount then
+                        caravanroutes[car].inventory.hasitem = false
+                        caravanroutes[car].inventory.item = ''
+                        caravanroutes[car].inventory.stackamount = 0
+                    else
+                        caravanroutes[car].inventory.stackamount = caravanroutes[car].inventory.stackamount - removedcount
+                    end
                 else
                     local contents = outpostinventory.get_contents()
                     --log(serpent.block(outpostinventory))


### PR DESCRIPTION
Full caravan goes to destination, unloads its cargo. If destination is already full (or limited by player and full up to limit), item still gets subtracted from caravan's inventory, but doesn't get added to destination (no space). End result: item gets lost.

Proposed change: caravan unloads as much as it can, and returns back with leftover cargo (which adds some headaches for the player, but at least stuff doesn't silently disappear).

P.S.: there's a copy of the code in `scripts/caravan.lua` which is never called by anything, so not sure why it even exists... is there a build script I'm not aware of?