### PR TITLE
Fix cadaveric recipes overridden by cadaveric machine.

### DIFF
--- a/prototypes/recipes/recipes-cadaveric.lua
+++ b/prototypes/recipes/recipes-cadaveric.lua
@@ -264,7 +264,7 @@ RECIPE {
 
 RECIPE {
     type = 'recipe',
-    name = 'cadaveric-arum-mk03',
+    name = 'cadaveric-arum-mk03-item',
     category = 'arum',
     enabled = false,
     energy_required = 30,
@@ -379,7 +379,7 @@ RECIPE {
 
 RECIPE {
     type = 'recipe',
-    name = 'cadaveric-arum-mk04',
+    name = 'cadaveric-arum-mk04-item',
     category = 'arum',
     enabled = false,
     energy_required = 30,


### PR DESCRIPTION
The names 'cadaveric-arum-mk03', 'cadaveric-arum-mk04' is already used by the recipe of the machine.

Solves #26 