### PR TITLE
Remove draw_entity_info_icon_background from buildings

### DIFF
--- a/prototypes/buildings/antelope-enclosure-mk01.lua
+++ b/prototypes/buildings/antelope-enclosure-mk01.lua
@@ -42,7 +42,6 @@ ENTITY {
     collision_box = {{-3.8, -3.8}, {3.8, 3.8}},
     selection_box = {{-4.0, -4.0}, {4.0, 4.0}},
     --collision_mask = {'ground-tile','water-tile','layer-14'},
-    draw_entity_info_icon_background = false,
     match_animation_speed_to_activity = false,
     module_specification = {
         module_slots = 3

--- a/prototypes/buildings/arthurian-pen-mk01.lua
+++ b/prototypes/buildings/arthurian-pen-mk01.lua
@@ -41,7 +41,6 @@ ENTITY {
     dying_explosion = "big-explosion",
     collision_box = {{-4.8, -4.8}, {4.8, 4.8}},
     selection_box = {{-5.0, -5.0}, {5.0, 5.0}},
-    draw_entity_info_icon_background = false,
     match_animation_speed_to_activity = false,
     module_specification = {
         module_slots = 8

--- a/prototypes/buildings/arthurian-pen-mk02.lua
+++ b/prototypes/buildings/arthurian-pen-mk02.lua
@@ -41,7 +41,6 @@ ENTITY {
     dying_explosion = "big-explosion",
     collision_box = {{-4.8, -4.8}, {4.8, 4.8}},
     selection_box = {{-5.0, -5.0}, {5.0, 5.0}},
-    draw_entity_info_icon_background = false,
     match_animation_speed_to_activity = false,
     module_specification = {
         module_slots = 16

--- a/prototypes/buildings/arthurian-pen-mk03.lua
+++ b/prototypes/buildings/arthurian-pen-mk03.lua
@@ -41,7 +41,6 @@ ENTITY {
     dying_explosion = "big-explosion",
     collision_box = {{-4.8, -4.8}, {4.8, 4.8}},
     selection_box = {{-5.0, -5.0}, {5.0, 5.0}},
-    draw_entity_info_icon_background = false,
     match_animation_speed_to_activity = false,
     module_specification = {
         module_slots = 24

--- a/prototypes/buildings/arthurian-pen-mk04.lua
+++ b/prototypes/buildings/arthurian-pen-mk04.lua
@@ -39,7 +39,6 @@ ENTITY {
     dying_explosion = "big-explosion",
     collision_box = {{-4.8, -4.8}, {4.8, 4.8}},
     selection_box = {{-5.0, -5.0}, {5.0, 5.0}},
-    draw_entity_info_icon_background = false,
     match_animation_speed_to_activity = false,
     module_specification = {
         module_slots = 32

--- a/prototypes/buildings/bhoddos-culture-mk01.lua
+++ b/prototypes/buildings/bhoddos-culture-mk01.lua
@@ -42,7 +42,6 @@ ENTITY {
     dying_explosion = "big-explosion",
     collision_box = {{-5.3, -5.3}, {5.3, 5.3}},
     selection_box = {{-5.5, -5.5}, {5.5, 5.5}},
-    draw_entity_info_icon_background = false,
     match_animation_speed_to_activity = false,
     module_specification = {
         module_slots = 1

--- a/prototypes/buildings/bhoddos-culture-mk02.lua
+++ b/prototypes/buildings/bhoddos-culture-mk02.lua
@@ -42,7 +42,6 @@ ENTITY {
     dying_explosion = "big-explosion",
     collision_box = {{-5.3, -5.3}, {5.3, 5.3}},
     selection_box = {{-5.5, -5.5}, {5.5, 5.5}},
-    draw_entity_info_icon_background = false,
     match_animation_speed_to_activity = false,
     module_specification = {
         module_slots = 2

--- a/prototypes/buildings/bhoddos-culture-mk03.lua
+++ b/prototypes/buildings/bhoddos-culture-mk03.lua
@@ -42,7 +42,6 @@ ENTITY {
     dying_explosion = "big-explosion",
     collision_box = {{-5.3, -5.3}, {5.3, 5.3}},
     selection_box = {{-5.5, -5.5}, {5.5, 5.5}},
-    draw_entity_info_icon_background = false,
     match_animation_speed_to_activity = false,
     module_specification = {
         module_slots = 3

--- a/prototypes/buildings/bhoddos-culture-mk04.lua
+++ b/prototypes/buildings/bhoddos-culture-mk04.lua
@@ -41,7 +41,6 @@ ENTITY {
     dying_explosion = "big-explosion",
     collision_box = {{-5.3, -5.3}, {5.3, 5.3}},
     selection_box = {{-5.5, -5.5}, {5.5, 5.5}},
-    draw_entity_info_icon_background = false,
     match_animation_speed_to_activity = false,
     module_specification = {
         module_slots = 4

--- a/prototypes/buildings/bio-printer-mk01.lua
+++ b/prototypes/buildings/bio-printer-mk01.lua
@@ -42,7 +42,6 @@ ENTITY {
     dying_explosion = "big-explosion",
     collision_box = {{-4.1, -4.1}, {4.1, 4.1}},
     selection_box = {{-4.5, -4.5}, {4.5, 4.5}},
-    draw_entity_info_icon_background = false,
     match_animation_speed_to_activity = false,
     module_specification = {
         module_slots = 1

--- a/prototypes/buildings/bio-printer-mk02.lua
+++ b/prototypes/buildings/bio-printer-mk02.lua
@@ -42,7 +42,6 @@ ENTITY {
     dying_explosion = "big-explosion",
     collision_box = {{-4.1, -4.1}, {4.1, 4.1}},
     selection_box = {{-4.5, -4.5}, {4.5, 4.5}},
-    draw_entity_info_icon_background = false,
     match_animation_speed_to_activity = false,
     module_specification = {
         module_slots = 2

--- a/prototypes/buildings/bio-printer-mk03.lua
+++ b/prototypes/buildings/bio-printer-mk03.lua
@@ -41,7 +41,6 @@ ENTITY {
     dying_explosion = "big-explosion",
     collision_box = {{-4.1, -4.1}, {4.1, 4.1}},
     selection_box = {{-4.5, -4.5}, {4.5, 4.5}},
-    draw_entity_info_icon_background = false,
     match_animation_speed_to_activity = false,
     module_specification = {
         module_slots = 3

--- a/prototypes/buildings/bio-printer-mk04.lua
+++ b/prototypes/buildings/bio-printer-mk04.lua
@@ -41,7 +41,6 @@ ENTITY {
     dying_explosion = "big-explosion",
     collision_box = {{-4.1, -4.1}, {4.1, 4.1}},
     selection_box = {{-4.5, -4.5}, {4.5, 4.5}},
-    draw_entity_info_icon_background = false,
     match_animation_speed_to_activity = false,
     module_specification = {
         module_slots = 3

--- a/prototypes/buildings/biofactory-mk01.lua
+++ b/prototypes/buildings/biofactory-mk01.lua
@@ -42,7 +42,6 @@ ENTITY {
     dying_explosion = "big-explosion",
     collision_box = {{-3.1, -3.1}, {3.1, 3.1}},
     selection_box = {{-3.5, -3.5}, {3.5, 3.5}},
-    draw_entity_info_icon_background = false,
     match_animation_speed_to_activity = false,
     module_specification = {
         module_slots = 1

--- a/prototypes/buildings/biofactory-mk02.lua
+++ b/prototypes/buildings/biofactory-mk02.lua
@@ -42,7 +42,6 @@ ENTITY {
     dying_explosion = "big-explosion",
     collision_box = {{-3.1, -3.1}, {3.1, 3.1}},
     selection_box = {{-3.5, -3.5}, {3.5, 3.5}},
-    draw_entity_info_icon_background = false,
     match_animation_speed_to_activity = false,
     module_specification = {
         module_slots = 2

--- a/prototypes/buildings/biofactory-mk03.lua
+++ b/prototypes/buildings/biofactory-mk03.lua
@@ -41,7 +41,6 @@ ENTITY {
     dying_explosion = "big-explosion",
     collision_box = {{-3.1, -3.1}, {3.1, 3.1}},
     selection_box = {{-3.5, -3.5}, {3.5, 3.5}},
-    draw_entity_info_icon_background = false,
     match_animation_speed_to_activity = false,
     module_specification = {
         module_slots = 3

--- a/prototypes/buildings/biofactory-mk04.lua
+++ b/prototypes/buildings/biofactory-mk04.lua
@@ -41,7 +41,6 @@ ENTITY {
     dying_explosion = "big-explosion",
     collision_box = {{-3.1, -3.1}, {3.1, 3.1}},
     selection_box = {{-3.5, -3.5}, {3.5, 3.5}},
-    draw_entity_info_icon_background = false,
     match_animation_speed_to_activity = false,
     module_specification = {
         module_slots = 4

--- a/prototypes/buildings/compost-plant-mk01.lua
+++ b/prototypes/buildings/compost-plant-mk01.lua
@@ -41,7 +41,6 @@ ENTITY {
     dying_explosion = "big-explosion",
     collision_box = {{-5.2, -5.2}, {5.2, 5.2}},
     selection_box = {{-5.5, -5.5}, {5.5, 5.5}},
-    draw_entity_info_icon_background = false,
     match_animation_speed_to_activity = false,
     module_specification = {
         module_slots = 1

--- a/prototypes/buildings/compost-plant-mk02.lua
+++ b/prototypes/buildings/compost-plant-mk02.lua
@@ -41,7 +41,6 @@ ENTITY {
     dying_explosion = "big-explosion",
     collision_box = {{-5.2, -5.2}, {5.2, 5.2}},
     selection_box = {{-5.5, -5.5}, {5.5, 5.5}},
-    draw_entity_info_icon_background = false,
     match_animation_speed_to_activity = false,
     module_specification = {
         module_slots = 2

--- a/prototypes/buildings/compost-plant-mk03.lua
+++ b/prototypes/buildings/compost-plant-mk03.lua
@@ -41,7 +41,6 @@ ENTITY {
     dying_explosion = "big-explosion",
     collision_box = {{-5.2, -5.2}, {5.2, 5.2}},
     selection_box = {{-5.5, -5.5}, {5.5, 5.5}},
-    draw_entity_info_icon_background = false,
     match_animation_speed_to_activity = false,
     module_specification = {
         module_slots = 3

--- a/prototypes/buildings/compost-plant-mk04.lua
+++ b/prototypes/buildings/compost-plant-mk04.lua
@@ -42,7 +42,6 @@ ENTITY {
     dying_explosion = "big-explosion",
     collision_box = {{-5.2, -5.2}, {5.2, 5.2}},
     selection_box = {{-5.5, -5.5}, {5.5, 5.5}},
-    draw_entity_info_icon_background = false,
     match_animation_speed_to_activity = false,
     module_specification = {
         module_slots = 4

--- a/prototypes/buildings/creature-chamber-mk01.lua
+++ b/prototypes/buildings/creature-chamber-mk01.lua
@@ -43,7 +43,6 @@ ENTITY {
     dying_explosion = "big-explosion",
     collision_box = {{-5.1, -5.1}, {5.1, 5.1}},
     selection_box = {{-5.5, -5.5}, {5.5, 5.5}},
-    draw_entity_info_icon_background = false,
     match_animation_speed_to_activity = false,
     module_specification = {
         module_slots = 1

--- a/prototypes/buildings/creature-chamber-mk02.lua
+++ b/prototypes/buildings/creature-chamber-mk02.lua
@@ -42,7 +42,6 @@ ENTITY {
     dying_explosion = "big-explosion",
     collision_box = {{-5.1, -5.1}, {5.1, 5.1}},
     selection_box = {{-5.5, -5.5}, {5.5, 5.5}},
-    draw_entity_info_icon_background = false,
     match_animation_speed_to_activity = false,
     module_specification = {
         module_slots = 2

--- a/prototypes/buildings/creature-chamber-mk03.lua
+++ b/prototypes/buildings/creature-chamber-mk03.lua
@@ -40,7 +40,6 @@ ENTITY {
     dying_explosion = "big-explosion",
     collision_box = {{-5.1, -5.1}, {5.1, 5.1}},
     selection_box = {{-5.5, -5.5}, {5.5, 5.5}},
-    draw_entity_info_icon_background = false,
     match_animation_speed_to_activity = false,
     module_specification = {
         module_slots = 3

--- a/prototypes/buildings/creature-chamber-mk04.lua
+++ b/prototypes/buildings/creature-chamber-mk04.lua
@@ -41,7 +41,6 @@ ENTITY {
     dying_explosion = "big-explosion",
     collision_box = {{-5.1, -5.1}, {5.1, 5.1}},
     selection_box = {{-5.5, -5.5}, {5.5, 5.5}},
-    draw_entity_info_icon_background = false,
     match_animation_speed_to_activity = false,
     module_specification = {
         module_slots = 4

--- a/prototypes/buildings/cridren-enclosure-mk01.lua
+++ b/prototypes/buildings/cridren-enclosure-mk01.lua
@@ -40,7 +40,6 @@ ENTITY {
     dying_explosion = "big-explosion",
     collision_box = {{-4.8, -4.8}, {4.8, 4.8}},
     selection_box = {{-5.0, -5.0}, {5.0, 5.0}},
-    draw_entity_info_icon_background = false,
     match_animation_speed_to_activity = false,
     module_specification = {
         module_slots = 1

--- a/prototypes/buildings/cridren-enclosure-mk02.lua
+++ b/prototypes/buildings/cridren-enclosure-mk02.lua
@@ -41,7 +41,6 @@ ENTITY {
     dying_explosion = "big-explosion",
     collision_box = {{-4.8, -4.8}, {4.8, 4.8}},
     selection_box = {{-5.0, -5.0}, {5.0, 5.0}},
-    draw_entity_info_icon_background = false,
     match_animation_speed_to_activity = false,
     module_specification = {
         module_slots = 2

--- a/prototypes/buildings/cridren-enclosure-mk03.lua
+++ b/prototypes/buildings/cridren-enclosure-mk03.lua
@@ -41,7 +41,6 @@ ENTITY {
     dying_explosion = "big-explosion",
     collision_box = {{-4.8, -4.8}, {4.8, 4.8}},
     selection_box = {{-5.0, -5.0}, {5.0, 5.0}},
-    draw_entity_info_icon_background = false,
     match_animation_speed_to_activity = false,
     module_specification = {
         module_slots = 3

--- a/prototypes/buildings/cridren-enclosure-mk04.lua
+++ b/prototypes/buildings/cridren-enclosure-mk04.lua
@@ -41,7 +41,6 @@ ENTITY {
     dying_explosion = "big-explosion",
     collision_box = {{-4.8, -4.8}, {4.8, 4.8}},
     selection_box = {{-5.0, -5.0}, {5.0, 5.0}},
-    draw_entity_info_icon_background = false,
     match_animation_speed_to_activity = false,
     module_specification = {
         module_slots = 4

--- a/prototypes/buildings/data-array.lua
+++ b/prototypes/buildings/data-array.lua
@@ -41,7 +41,6 @@ ENTITY {
     dying_explosion = "big-explosion",
     collision_box = {{-4.8, -4.8}, {4.8, 4.8}},
     selection_box = {{-5.0, -5.0}, {5.0, 5.0}},
-    --draw_entity_info_icon_background = false,
     match_animation_speed_to_activity = false,
     module_specification = {
         module_slots = 5

--- a/prototypes/buildings/dhilmos-pool-mk01.lua
+++ b/prototypes/buildings/dhilmos-pool-mk01.lua
@@ -43,7 +43,6 @@ ENTITY {
     dying_explosion = "big-explosion",
     collision_box = {{-5.2, -5.2}, {5.2, 5.2}},
     selection_box = {{-5.5, -5.5}, {5.5, 5.5}},
-    draw_entity_info_icon_background = false,
     match_animation_speed_to_activity = false,
     module_specification = {
         module_slots = 5

--- a/prototypes/buildings/dhilmos-pool-mk02.lua
+++ b/prototypes/buildings/dhilmos-pool-mk02.lua
@@ -43,7 +43,6 @@ ENTITY {
     dying_explosion = "big-explosion",
     collision_box = {{-5.2, -5.2}, {5.2, 5.2}},
     selection_box = {{-5.5, -5.5}, {5.5, 5.5}},
-    draw_entity_info_icon_background = false,
     match_animation_speed_to_activity = false,
     module_specification = {
         module_slots = 10

--- a/prototypes/buildings/dhilmos-pool-mk03.lua
+++ b/prototypes/buildings/dhilmos-pool-mk03.lua
@@ -40,7 +40,6 @@ ENTITY {
     dying_explosion = "big-explosion",
     collision_box = {{-5.2, -5.2}, {5.2, 5.2}},
     selection_box = {{-5.5, -5.5}, {5.5, 5.5}},
-    draw_entity_info_icon_background = false,
     match_animation_speed_to_activity = false,
     module_specification = {
         module_slots = 15

--- a/prototypes/buildings/dhilmos-pool-mk04.lua
+++ b/prototypes/buildings/dhilmos-pool-mk04.lua
@@ -40,7 +40,6 @@ ENTITY {
     dying_explosion = "big-explosion",
     collision_box = {{-5.2, -5.2}, {5.2, 5.2}},
     selection_box = {{-5.5, -5.5}, {5.5, 5.5}},
-    draw_entity_info_icon_background = false,
     match_animation_speed_to_activity = false,
     module_specification = {
         module_slots = 20

--- a/prototypes/buildings/dingrits-pack-mk01.lua
+++ b/prototypes/buildings/dingrits-pack-mk01.lua
@@ -41,7 +41,6 @@ ENTITY {
     dying_explosion = "big-explosion",
     collision_box = {{-6.8, -6.8}, {6.8, 6.8}},
     selection_box = {{-7.0, -7.0}, {7.0, 7.0}},
-    --draw_entity_info_icon_background = false,
     match_animation_speed_to_activity = false,
     module_specification = {
         module_slots = 20

--- a/prototypes/buildings/dingrits-pack-mk02.lua
+++ b/prototypes/buildings/dingrits-pack-mk02.lua
@@ -41,7 +41,6 @@ ENTITY {
     dying_explosion = "big-explosion",
     collision_box = {{-6.8, -6.8}, {6.8, 6.8}},
     selection_box = {{-7.0, -7.0}, {7.0, 7.0}},
-    --draw_entity_info_icon_background = false,
     match_animation_speed_to_activity = false,
     module_specification = {
         module_slots = 30

--- a/prototypes/buildings/dingrits-pack-mk03.lua
+++ b/prototypes/buildings/dingrits-pack-mk03.lua
@@ -41,7 +41,6 @@ ENTITY {
     dying_explosion = "big-explosion",
     collision_box = {{-6.8, -6.8}, {6.8, 6.8}},
     selection_box = {{-7.0, -7.0}, {7.0, 7.0}},
-    --draw_entity_info_icon_background = false,
     match_animation_speed_to_activity = false,
     module_specification = {
         module_slots = 40

--- a/prototypes/buildings/dingrits-pack-mk04.lua
+++ b/prototypes/buildings/dingrits-pack-mk04.lua
@@ -41,7 +41,6 @@ ENTITY {
     dying_explosion = "big-explosion",
     collision_box = {{-6.8, -6.8}, {6.8, 6.8}},
     selection_box = {{-7.0, -7.0}, {7.0, 7.0}},
-    --draw_entity_info_icon_background = false,
     match_animation_speed_to_activity = false,
     module_specification = {
         module_slots = 50

--- a/prototypes/buildings/ez-ranch-mk01.lua
+++ b/prototypes/buildings/ez-ranch-mk01.lua
@@ -41,7 +41,6 @@ ENTITY {
     dying_explosion = "big-explosion",
     collision_box = {{-4.8, -4.8}, {4.8, 4.8}},
     selection_box = {{-5.0, -5.0}, {5.0, 5.0}},
-    draw_entity_info_icon_background = false,
     match_animation_speed_to_activity = false,
     module_specification = {
         module_slots = 20

--- a/prototypes/buildings/ez-ranch-mk02.lua
+++ b/prototypes/buildings/ez-ranch-mk02.lua
@@ -42,7 +42,6 @@ ENTITY {
     dying_explosion = "big-explosion",
     collision_box = {{-4.8, -4.8}, {4.8, 4.8}},
     selection_box = {{-5.0, -5.0}, {5.0, 5.0}},
-    draw_entity_info_icon_background = false,
     match_animation_speed_to_activity = false,
     module_specification = {
         module_slots = 32

--- a/prototypes/buildings/ez-ranch-mk03.lua
+++ b/prototypes/buildings/ez-ranch-mk03.lua
@@ -41,7 +41,6 @@ ENTITY {
     dying_explosion = "big-explosion",
     collision_box = {{-4.8, -4.8}, {4.8, 4.8}},
     selection_box = {{-5.0, -5.0}, {5.0, 5.0}},
-    draw_entity_info_icon_background = false,
     match_animation_speed_to_activity = false,
     module_specification = {
         module_slots = 40

--- a/prototypes/buildings/ez-ranch-mk04.lua
+++ b/prototypes/buildings/ez-ranch-mk04.lua
@@ -41,7 +41,6 @@ ENTITY {
     dying_explosion = "big-explosion",
     collision_box = {{-4.8, -4.8}, {4.8, 4.8}},
     selection_box = {{-5.0, -5.0}, {5.0, 5.0}},
-    draw_entity_info_icon_background = false,
     match_animation_speed_to_activity = false,
     module_specification = {
         module_slots = 52

--- a/prototypes/buildings/fish-farm-mk01.lua
+++ b/prototypes/buildings/fish-farm-mk01.lua
@@ -44,7 +44,6 @@ ENTITY {
     dying_explosion = "big-explosion",
     collision_box = {{-5.1, -5.1}, {5.1, 5.1}},
     selection_box = {{-5.5, -5.5}, {5.5, 5.5}},
-    draw_entity_info_icon_background = false,
     match_animation_speed_to_activity = false,
     module_specification = {
         module_slots = 7

--- a/prototypes/buildings/fish-farm-mk02.lua
+++ b/prototypes/buildings/fish-farm-mk02.lua
@@ -42,7 +42,6 @@ ENTITY {
     dying_explosion = "big-explosion",
     collision_box = {{-5.1, -5.1}, {5.1, 5.1}},
     selection_box = {{-5.5, -5.5}, {5.5, 5.5}},
-    draw_entity_info_icon_background = false,
     match_animation_speed_to_activity = false,
     module_specification = {
         module_slots = 14

--- a/prototypes/buildings/fish-farm-mk03.lua
+++ b/prototypes/buildings/fish-farm-mk03.lua
@@ -41,7 +41,6 @@ ENTITY {
     dying_explosion = "big-explosion",
     collision_box = {{-5.1, -5.1}, {5.1, 5.1}},
     selection_box = {{-5.5, -5.5}, {5.5, 5.5}},
-    draw_entity_info_icon_background = false,
     match_animation_speed_to_activity = false,
     module_specification = {
         module_slots = 20

--- a/prototypes/buildings/fish-farm-mk04.lua
+++ b/prototypes/buildings/fish-farm-mk04.lua
@@ -42,7 +42,6 @@ ENTITY {
     dying_explosion = "big-explosion",
     collision_box = {{-5.1, -5.1}, {5.1, 5.1}},
     selection_box = {{-5.5, -5.5}, {5.5, 5.5}},
-    draw_entity_info_icon_background = false,
     match_animation_speed_to_activity = false,
     module_specification = {
         module_slots = 27

--- a/prototypes/buildings/fwf-mk01.lua
+++ b/prototypes/buildings/fwf-mk01.lua
@@ -40,7 +40,6 @@ ENTITY {
     dying_explosion = "big-explosion",
     collision_box = {{-5.1, -5.1}, {5.1, 5.1}},
     selection_box = {{-5.5, -5.5}, {5.5, 5.5}},
-    draw_entity_info_icon_background = false,
     match_animation_speed_to_activity = false,
     module_specification = {
         module_slots = 25

--- a/prototypes/buildings/fwf-mk02.lua
+++ b/prototypes/buildings/fwf-mk02.lua
@@ -42,7 +42,6 @@ ENTITY {
     dying_explosion = "big-explosion",
     collision_box = {{-5.1, -5.1}, {5.1, 5.1}},
     selection_box = {{-5.5, -5.5}, {5.5, 5.5}},
-    draw_entity_info_icon_background = false,
     match_animation_speed_to_activity = false,
     module_specification = {
         module_slots = 50

--- a/prototypes/buildings/fwf-mk03.lua
+++ b/prototypes/buildings/fwf-mk03.lua
@@ -41,7 +41,6 @@ ENTITY {
     dying_explosion = "big-explosion",
     collision_box = {{-5.1, -5.1}, {5.1, 5.1}},
     selection_box = {{-5.5, -5.5}, {5.5, 5.5}},
-    draw_entity_info_icon_background = false,
     match_animation_speed_to_activity = false,
     module_specification = {
         module_slots = 75

--- a/prototypes/buildings/fwf-mk04.lua
+++ b/prototypes/buildings/fwf-mk04.lua
@@ -41,7 +41,6 @@ ENTITY {
     dying_explosion = "big-explosion",
     collision_box = {{-5.1, -5.1}, {5.1, 5.1}},
     selection_box = {{-5.5, -5.5}, {5.5, 5.5}},
-    draw_entity_info_icon_background = false,
     match_animation_speed_to_activity = false,
     module_specification = {
         module_slots = 100

--- a/prototypes/buildings/genlab-mk01.lua
+++ b/prototypes/buildings/genlab-mk01.lua
@@ -43,7 +43,6 @@ ENTITY {
     dying_explosion = "big-explosion",
     collision_box = {{-3.1, -3.1}, {3.1, 3.1}},
     selection_box = {{-3.5, -3.5}, {3.5, 3.5}},
-    draw_entity_info_icon_background = false,
     match_animation_speed_to_activity = false,
     module_specification = {
         module_slots = 1

--- a/prototypes/buildings/genlab-mk02.lua
+++ b/prototypes/buildings/genlab-mk02.lua
@@ -42,7 +42,6 @@ ENTITY {
     dying_explosion = "big-explosion",
     collision_box = {{-3.1, -3.1}, {3.1, 3.1}},
     selection_box = {{-3.5, -3.5}, {3.5, 3.5}},
-    draw_entity_info_icon_background = false,
     match_animation_speed_to_activity = false,
     module_specification = {
         module_slots = 2

--- a/prototypes/buildings/genlab-mk03.lua
+++ b/prototypes/buildings/genlab-mk03.lua
@@ -42,7 +42,6 @@ ENTITY {
     dying_explosion = "big-explosion",
     collision_box = {{-3.1, -3.1}, {3.1, 3.1}},
     selection_box = {{-3.5, -3.5}, {3.5, 3.5}},
-    draw_entity_info_icon_background = false,
     match_animation_speed_to_activity = false,
     module_specification = {
         module_slots = 3

--- a/prototypes/buildings/genlab-mk04.lua
+++ b/prototypes/buildings/genlab-mk04.lua
@@ -41,7 +41,6 @@ ENTITY {
     dying_explosion = "big-explosion",
     collision_box = {{-3.1, -3.1}, {3.1, 3.1}},
     selection_box = {{-3.5, -3.5}, {3.5, 3.5}},
-    draw_entity_info_icon_background = false,
     match_animation_speed_to_activity = false,
     module_specification = {
         module_slots = 4

--- a/prototypes/buildings/grod-swamp-mk01.lua
+++ b/prototypes/buildings/grod-swamp-mk01.lua
@@ -44,7 +44,6 @@ ENTITY {
     dying_explosion = "big-explosion",
     collision_box = {{-5.2, -5.2}, {5.2, 5.2}},
     selection_box = {{-5.5, -5.5}, {5.5, 5.5}},
-    --draw_entity_info_icon_background = false,
     match_animation_speed_to_activity = false,
     module_specification = {
         module_slots = 7

--- a/prototypes/buildings/grod-swamp-mk02.lua
+++ b/prototypes/buildings/grod-swamp-mk02.lua
@@ -43,7 +43,6 @@ ENTITY {
     dying_explosion = "big-explosion",
     collision_box = {{-5.2, -5.2}, {5.2, 5.2}},
     selection_box = {{-5.5, -5.5}, {5.5, 5.5}},
-    --draw_entity_info_icon_background = false,
     match_animation_speed_to_activity = false,
     module_specification = {
         module_slots = 14

--- a/prototypes/buildings/grod-swamp-mk03.lua
+++ b/prototypes/buildings/grod-swamp-mk03.lua
@@ -41,7 +41,6 @@ ENTITY {
     dying_explosion = "big-explosion",
     collision_box = {{-5.2, -5.2}, {5.2, 5.2}},
     selection_box = {{-5.5, -5.5}, {5.5, 5.5}},
-    --draw_entity_info_icon_background = false,
     match_animation_speed_to_activity = false,
     module_specification = {
         module_slots = 21

--- a/prototypes/buildings/grod-swamp-mk04.lua
+++ b/prototypes/buildings/grod-swamp-mk04.lua
@@ -41,7 +41,6 @@ ENTITY {
     dying_explosion = "big-explosion",
     collision_box = {{-5.2, -5.2}, {5.2, 5.2}},
     selection_box = {{-5.5, -5.5}, {5.5, 5.5}},
-    --draw_entity_info_icon_background = false,
     match_animation_speed_to_activity = false,
     module_specification = {
         module_slots = 28

--- a/prototypes/buildings/incubator-mk01.lua
+++ b/prototypes/buildings/incubator-mk01.lua
@@ -51,7 +51,6 @@ ENTITY {
     dying_explosion = "medium-explosion",
     collision_box = {{-3.2, -3.2}, {3.2, 3.2}},
     selection_box = {{-3.5, -3.5}, {3.5, 3.5}},
-    draw_entity_info_icon_background = false,
     match_animation_speed_to_activity = false,
     module_specification = {
         module_slots = 1

--- a/prototypes/buildings/incubator-mk02.lua
+++ b/prototypes/buildings/incubator-mk02.lua
@@ -52,7 +52,6 @@ ENTITY {
     dying_explosion = "medium-explosion",
     collision_box = {{-3.2, -3.2}, {3.2, 3.2}},
     selection_box = {{-3.5, -3.5}, {3.5, 3.5}},
-    draw_entity_info_icon_background = false,
     match_animation_speed_to_activity = false,
     module_specification = {
         module_slots = 2

--- a/prototypes/buildings/incubator-mk03.lua
+++ b/prototypes/buildings/incubator-mk03.lua
@@ -51,7 +51,6 @@ ENTITY {
     dying_explosion = "medium-explosion",
     collision_box = {{-3.2, -3.2}, {3.2, 3.2}},
     selection_box = {{-3.5, -3.5}, {3.5, 3.5}},
-    draw_entity_info_icon_background = false,
     match_animation_speed_to_activity = false,
     module_specification = {
         module_slots = 3

--- a/prototypes/buildings/incubator-mk04.lua
+++ b/prototypes/buildings/incubator-mk04.lua
@@ -51,7 +51,6 @@ ENTITY {
     dying_explosion = "medium-explosion",
     collision_box = {{-3.2, -3.2}, {3.2, 3.2}},
     selection_box = {{-3.5, -3.5}, {3.5, 3.5}},
-    draw_entity_info_icon_background = false,
     match_animation_speed_to_activity = false,
     module_specification = {
         module_slots = 4

--- a/prototypes/buildings/micro-mine-mk01.lua
+++ b/prototypes/buildings/micro-mine-mk01.lua
@@ -42,7 +42,6 @@ ENTITY {
     dying_explosion = "big-explosion",
     collision_box = {{-3.2, -3.2}, {3.2, 3.2}},
     selection_box = {{-3.5, -3.5}, {3.5, 3.5}},
-    draw_entity_info_icon_background = false,
     match_animation_speed_to_activity = false,
     module_specification = {
         module_slots = 1

--- a/prototypes/buildings/micro-mine-mk02.lua
+++ b/prototypes/buildings/micro-mine-mk02.lua
@@ -41,7 +41,6 @@ ENTITY {
     dying_explosion = "big-explosion",
     collision_box = {{-3.2, -3.2}, {3.2, 3.2}},
     selection_box = {{-3.5, -3.5}, {3.5, 3.5}},
-    draw_entity_info_icon_background = false,
     match_animation_speed_to_activity = false,
     module_specification = {
         module_slots = 2

--- a/prototypes/buildings/micro-mine-mk03.lua
+++ b/prototypes/buildings/micro-mine-mk03.lua
@@ -42,7 +42,6 @@ ENTITY {
     dying_explosion = "big-explosion",
     collision_box = {{-3.2, -3.2}, {3.2, 3.2}},
     selection_box = {{-3.5, -3.5}, {3.5, 3.5}},
-    draw_entity_info_icon_background = false,
     match_animation_speed_to_activity = false,
     module_specification = {
         module_slots = 3

--- a/prototypes/buildings/micro-mine-mk04.lua
+++ b/prototypes/buildings/micro-mine-mk04.lua
@@ -42,7 +42,6 @@ ENTITY {
     dying_explosion = "big-explosion",
     collision_box = {{-3.2, -3.2}, {3.2, 3.2}},
     selection_box = {{-3.5, -3.5}, {3.5, 3.5}},
-    draw_entity_info_icon_background = false,
     match_animation_speed_to_activity = false,
     module_specification = {
         module_slots = 4

--- a/prototypes/buildings/moss-farm-mk02.lua
+++ b/prototypes/buildings/moss-farm-mk02.lua
@@ -41,7 +41,6 @@ ENTITY {
     dying_explosion = "big-explosion",
     collision_box = {{-2.9, -2.9}, {2.9, 2.9}},
     selection_box = {{-3.0, -3.0}, {3.0, 3.0}},
-    draw_entity_info_icon_background = false,
     match_animation_speed_to_activity = false,
     module_specification = {
         module_slots = 30

--- a/prototypes/buildings/moss-farm-mk03.lua
+++ b/prototypes/buildings/moss-farm-mk03.lua
@@ -41,7 +41,6 @@ ENTITY {
     dying_explosion = "big-explosion",
     collision_box = {{-2.9, -2.9}, {2.9, 2.9}},
     selection_box = {{-3.0, -3.0}, {3.0, 3.0}},
-    draw_entity_info_icon_background = false,
     match_animation_speed_to_activity = false,
     module_specification = {
         module_slots = 45

--- a/prototypes/buildings/moss-farm-mk04.lua
+++ b/prototypes/buildings/moss-farm-mk04.lua
@@ -41,7 +41,6 @@ ENTITY {
     dying_explosion = "big-explosion",
     collision_box = {{-2.9, -2.9}, {2.9, 2.9}},
     selection_box = {{-3.0, -3.0}, {3.0, 3.0}},
-    draw_entity_info_icon_background = false,
     match_animation_speed_to_activity = false,
     module_specification = {
         module_slots = 60

--- a/prototypes/buildings/moss-farm.lua
+++ b/prototypes/buildings/moss-farm.lua
@@ -41,7 +41,6 @@ ENTITY {
     dying_explosion = "big-explosion",
     collision_box = {{-2.9, -2.9}, {2.9, 2.9}},
     selection_box = {{-3.0, -3.0}, {3.0, 3.0}},
-    draw_entity_info_icon_background = false,
     match_animation_speed_to_activity = false,
     module_specification = {
         module_slots = 15

--- a/prototypes/buildings/mukmoux-pasture-mk01.lua
+++ b/prototypes/buildings/mukmoux-pasture-mk01.lua
@@ -40,7 +40,6 @@ ENTITY {
     dying_explosion = "big-explosion",
     collision_box = {{-7.2, -7.2}, {7.2, 7.2}},
     selection_box = {{-7.5, -7.5}, {7.5, 7.5}},
-    draw_entity_info_icon_background = false,
     match_animation_speed_to_activity = false,
     module_specification = {
         module_slots = 8

--- a/prototypes/buildings/mukmoux-pasture-mk02.lua
+++ b/prototypes/buildings/mukmoux-pasture-mk02.lua
@@ -40,7 +40,6 @@ ENTITY {
     dying_explosion = "big-explosion",
     collision_box = {{-7.2, -7.2}, {7.2, 7.2}},
     selection_box = {{-7.5, -7.5}, {7.5, 7.5}},
-    draw_entity_info_icon_background = false,
     match_animation_speed_to_activity = false,
     module_specification = {
         module_slots = 15

--- a/prototypes/buildings/mukmoux-pasture-mk03.lua
+++ b/prototypes/buildings/mukmoux-pasture-mk03.lua
@@ -40,7 +40,6 @@ ENTITY {
     dying_explosion = "big-explosion",
     collision_box = {{-7.2, -7.2}, {7.2, 7.2}},
     selection_box = {{-7.5, -7.5}, {7.5, 7.5}},
-    draw_entity_info_icon_background = false,
     match_animation_speed_to_activity = false,
     module_specification = {
         module_slots = 20

--- a/prototypes/buildings/mukmoux-pasture-mk04.lua
+++ b/prototypes/buildings/mukmoux-pasture-mk04.lua
@@ -40,7 +40,6 @@ ENTITY {
     dying_explosion = "big-explosion",
     collision_box = {{-7.2, -7.2}, {7.2, 7.2}},
     selection_box = {{-7.5, -7.5}, {7.5, 7.5}},
-    draw_entity_info_icon_background = false,
     match_animation_speed_to_activity = false,
     module_specification = {
         module_slots = 25

--- a/prototypes/buildings/navens-culture-mk01.lua
+++ b/prototypes/buildings/navens-culture-mk01.lua
@@ -42,7 +42,6 @@ ENTITY {
     dying_explosion = "big-explosion",
     collision_box = {{-4.8, -4.8}, {4.8, 4.8}},
     selection_box = {{-5.0, -5.0}, {5.0, 5.0}},
-    draw_entity_info_icon_background = false,
     match_animation_speed_to_activity = false,
     module_specification = {
         module_slots = 4

--- a/prototypes/buildings/navens-culture-mk02.lua
+++ b/prototypes/buildings/navens-culture-mk02.lua
@@ -41,7 +41,6 @@ ENTITY {
     dying_explosion = "big-explosion",
     collision_box = {{-4.8, -4.8}, {4.8, 4.8}},
     selection_box = {{-5.0, -5.0}, {5.0, 5.0}},
-    draw_entity_info_icon_background = false,
     match_animation_speed_to_activity = false,
     module_specification = {
         module_slots = 7

--- a/prototypes/buildings/navens-culture-mk03.lua
+++ b/prototypes/buildings/navens-culture-mk03.lua
@@ -41,7 +41,6 @@ ENTITY {
     dying_explosion = "big-explosion",
     collision_box = {{-4.8, -4.8}, {4.8, 4.8}},
     selection_box = {{-5.0, -5.0}, {5.0, 5.0}},
-    draw_entity_info_icon_background = false,
     match_animation_speed_to_activity = false,
     module_specification = {
         module_slots = 10

--- a/prototypes/buildings/navens-culture-mk04.lua
+++ b/prototypes/buildings/navens-culture-mk04.lua
@@ -40,7 +40,6 @@ ENTITY {
     dying_explosion = "big-explosion",
     collision_box = {{-4.8, -4.8}, {4.8, 4.8}},
     selection_box = {{-5.0, -5.0}, {5.0, 5.0}},
-    draw_entity_info_icon_background = false,
     match_animation_speed_to_activity = false,
     module_specification = {
         module_slots = 14

--- a/prototypes/buildings/phadai-enclosure-mk01.lua
+++ b/prototypes/buildings/phadai-enclosure-mk01.lua
@@ -41,7 +41,6 @@ ENTITY {
     dying_explosion = "big-explosion",
     collision_box = {{-6.2, -6.2}, {6.2, 6.2}},
     selection_box = {{-6.5, -6.5}, {6.5, 6.5}},
-    --draw_entity_info_icon_background = false,
     match_animation_speed_to_activity = false,
     module_specification = {
         module_slots = 5

--- a/prototypes/buildings/phadai-enclosure-mk02.lua
+++ b/prototypes/buildings/phadai-enclosure-mk02.lua
@@ -41,7 +41,6 @@ ENTITY {
     dying_explosion = "big-explosion",
     collision_box = {{-6.2, -6.2}, {6.2, 6.2}},
     selection_box = {{-6.5, -6.5}, {6.5, 6.5}},
-    --draw_entity_info_icon_background = false,
     match_animation_speed_to_activity = false,
     module_specification = {
         module_slots = 8

--- a/prototypes/buildings/phadai-enclosure-mk03.lua
+++ b/prototypes/buildings/phadai-enclosure-mk03.lua
@@ -41,7 +41,6 @@ ENTITY {
     dying_explosion = "big-explosion",
     collision_box = {{-6.2, -6.2}, {6.2, 6.2}},
     selection_box = {{-6.5, -6.5}, {6.5, 6.5}},
-    --draw_entity_info_icon_background = false,
     match_animation_speed_to_activity = false,
     module_specification = {
         module_slots = 10

--- a/prototypes/buildings/phadai-enclosure-mk04.lua
+++ b/prototypes/buildings/phadai-enclosure-mk04.lua
@@ -41,7 +41,6 @@ ENTITY {
     dying_explosion = "big-explosion",
     collision_box = {{-6.2, -6.2}, {6.2, 6.2}},
     selection_box = {{-6.5, -6.5}, {6.5, 6.5}},
-    --draw_entity_info_icon_background = false,
     match_animation_speed_to_activity = false,
     module_specification = {
         module_slots = 13

--- a/prototypes/buildings/phagnot-corral-mk01.lua
+++ b/prototypes/buildings/phagnot-corral-mk01.lua
@@ -41,7 +41,6 @@ ENTITY {
     dying_explosion = "big-explosion",
     collision_box = {{-5.8, -5.8}, {5.8, 5.8}},
     selection_box = {{-6.0, -6.0}, {6.0, 6.0}},
-    draw_entity_info_icon_background = false,
     match_animation_speed_to_activity = false,
     module_specification = {
         module_slots = 10

--- a/prototypes/buildings/phagnot-corral-mk02.lua
+++ b/prototypes/buildings/phagnot-corral-mk02.lua
@@ -41,7 +41,6 @@ ENTITY {
     dying_explosion = "big-explosion",
     collision_box = {{-5.8, -5.8}, {5.8, 5.8}},
     selection_box = {{-6.0, -6.0}, {6.0, 6.0}},
-    draw_entity_info_icon_background = false,
     match_animation_speed_to_activity = false,
     module_specification = {
         module_slots = 20

--- a/prototypes/buildings/phagnot-corral-mk03.lua
+++ b/prototypes/buildings/phagnot-corral-mk03.lua
@@ -41,7 +41,6 @@ ENTITY {
     dying_explosion = "big-explosion",
     collision_box = {{-5.8, -5.8}, {5.8, 5.8}},
     selection_box = {{-6.0, -6.0}, {6.0, 6.0}},
-    draw_entity_info_icon_background = false,
     match_animation_speed_to_activity = false,
     module_specification = {
         module_slots = 30

--- a/prototypes/buildings/phagnot-corral-mk04.lua
+++ b/prototypes/buildings/phagnot-corral-mk04.lua
@@ -41,7 +41,6 @@ ENTITY {
     dying_explosion = "big-explosion",
     collision_box = {{-5.8, -5.8}, {5.8, 5.8}},
     selection_box = {{-6.0, -6.0}, {6.0, 6.0}},
-    draw_entity_info_icon_background = false,
     match_animation_speed_to_activity = false,
     module_specification = {
         module_slots = 40

--- a/prototypes/buildings/pyphoon-bay.lua
+++ b/prototypes/buildings/pyphoon-bay.lua
@@ -42,7 +42,6 @@ ENTITY {
     dying_explosion = "big-explosion",
     collision_box = {{-4.8, -4.8}, {4.8, 4.8}},
     selection_box = {{-5.0, -5.0}, {5.0, 5.0}},
-    --draw_entity_info_icon_background = false,
     match_animation_speed_to_activity = false,
     module_specification = {
         module_slots = 4

--- a/prototypes/buildings/ralesia-plantation-mk01.lua
+++ b/prototypes/buildings/ralesia-plantation-mk01.lua
@@ -70,7 +70,6 @@ ENTITY {
     dying_explosion = "medium-explosion",
     collision_box = {{-3.2, -3.2}, {3.2, 3.2}},
     selection_box = {{-3.5, -3.5}, {3.5, 3.5}},
-    draw_entity_info_icon_background = false,
     match_animation_speed_to_activity = false,
     module_specification = {
         module_slots = 12

--- a/prototypes/buildings/ralesia-plantation-mk02.lua
+++ b/prototypes/buildings/ralesia-plantation-mk02.lua
@@ -68,7 +68,6 @@ ENTITY {
     dying_explosion = "medium-explosion",
     collision_box = {{-3.2, -3.2}, {3.2, 3.2}},
     selection_box = {{-3.5, -3.5}, {3.5, 3.5}},
-    draw_entity_info_icon_background = false,
     match_animation_speed_to_activity = false,
     module_specification = {
         module_slots = 24

--- a/prototypes/buildings/ralesia-plantation-mk03.lua
+++ b/prototypes/buildings/ralesia-plantation-mk03.lua
@@ -66,7 +66,6 @@ ENTITY {
     dying_explosion = "medium-explosion",
     collision_box = {{-3.2, -3.2}, {3.2, 3.2}},
     selection_box = {{-3.5, -3.5}, {3.5, 3.5}},
-    draw_entity_info_icon_background = false,
     match_animation_speed_to_activity = false,
     module_specification = {
         module_slots = 36

--- a/prototypes/buildings/ralesia-plantation-mk04.lua
+++ b/prototypes/buildings/ralesia-plantation-mk04.lua
@@ -68,7 +68,6 @@ ENTITY {
     dying_explosion = "medium-explosion",
     collision_box = {{-3.2, -3.2}, {3.2, 3.2}},
     selection_box = {{-3.5, -3.5}, {3.5, 3.5}},
-    draw_entity_info_icon_background = false,
     match_animation_speed_to_activity = false,
     module_specification = {
         module_slots = 48

--- a/prototypes/buildings/rennea-plantation-mk01.lua
+++ b/prototypes/buildings/rennea-plantation-mk01.lua
@@ -44,7 +44,6 @@ ENTITY {
     dying_explosion = "big-explosion",
     collision_box = {{-6.2, -6.2}, {6.2, 6.2}},
     selection_box = {{-6.5, -6.5}, {6.5, 6.5}},
-    --draw_entity_info_icon_background = false,
     match_animation_speed_to_activity = false,
     module_specification = {
         module_slots = 30

--- a/prototypes/buildings/rennea-plantation-mk02.lua
+++ b/prototypes/buildings/rennea-plantation-mk02.lua
@@ -42,7 +42,6 @@ ENTITY {
     dying_explosion = "big-explosion",
     collision_box = {{-6.2, -6.2}, {6.2, 6.2}},
     selection_box = {{-6.5, -6.5}, {6.5, 6.5}},
-    --draw_entity_info_icon_background = false,
     match_animation_speed_to_activity = false,
     module_specification = {
         module_slots = 60

--- a/prototypes/buildings/rennea-plantation-mk03.lua
+++ b/prototypes/buildings/rennea-plantation-mk03.lua
@@ -41,7 +41,6 @@ ENTITY {
     dying_explosion = "big-explosion",
     collision_box = {{-6.2, -6.2}, {6.2, 6.2}},
     selection_box = {{-6.5, -6.5}, {6.5, 6.5}},
-    --draw_entity_info_icon_background = false,
     match_animation_speed_to_activity = false,
     module_specification = {
         module_slots = 90

--- a/prototypes/buildings/rennea-plantation-mk04.lua
+++ b/prototypes/buildings/rennea-plantation-mk04.lua
@@ -41,7 +41,6 @@ ENTITY {
     dying_explosion = "big-explosion",
     collision_box = {{-6.2, -6.2}, {6.2, 6.2}},
     selection_box = {{-6.5, -6.5}, {6.5, 6.5}},
-    --draw_entity_info_icon_background = false,
     match_animation_speed_to_activity = false,
     module_specification = {
         module_slots = 120

--- a/prototypes/buildings/sap-extractor-mk01.lua
+++ b/prototypes/buildings/sap-extractor-mk01.lua
@@ -41,7 +41,6 @@ ENTITY {
     dying_explosion = "big-explosion",
     collision_box = {{-2.4, -2.4}, {2.4, 2.4}},
     selection_box = {{-2.5, -2.5}, {2.5, 2.5}},
-    draw_entity_info_icon_background = false,
     match_animation_speed_to_activity = false,
     fixed_recipe = "sap-01",
     module_specification = {

--- a/prototypes/buildings/sap-extractor-mk02.lua
+++ b/prototypes/buildings/sap-extractor-mk02.lua
@@ -41,7 +41,6 @@ ENTITY {
     dying_explosion = "big-explosion",
     collision_box = {{-2.4, -2.4}, {2.4, 2.4}},
     selection_box = {{-2.5, -2.5}, {2.5, 2.5}},
-    draw_entity_info_icon_background = false,
     match_animation_speed_to_activity = false,
     fixed_recipe = "sap-01",
     module_specification = {

--- a/prototypes/buildings/sap-extractor-mk03.lua
+++ b/prototypes/buildings/sap-extractor-mk03.lua
@@ -41,7 +41,6 @@ ENTITY {
     dying_explosion = "big-explosion",
     collision_box = {{-2.4, -2.4}, {2.4, 2.4}},
     selection_box = {{-2.5, -2.5}, {2.5, 2.5}},
-    draw_entity_info_icon_background = false,
     match_animation_speed_to_activity = false,
     fixed_recipe = "sap-01",
     module_specification = {

--- a/prototypes/buildings/sap-extractor-mk04.lua
+++ b/prototypes/buildings/sap-extractor-mk04.lua
@@ -41,7 +41,6 @@ ENTITY {
     dying_explosion = "big-explosion",
     collision_box = {{-2.4, -2.4}, {2.4, 2.4}},
     selection_box = {{-2.5, -2.5}, {2.5, 2.5}},
-    draw_entity_info_icon_background = false,
     match_animation_speed_to_activity = false,
     fixed_recipe = "sap-01",
     module_specification = {

--- a/prototypes/buildings/scrondrix-pen-mk01.lua
+++ b/prototypes/buildings/scrondrix-pen-mk01.lua
@@ -41,7 +41,6 @@ ENTITY {
     dying_explosion = "big-explosion",
     collision_box = {{-5.2, -5.2}, {5.2, 5.2}},
     selection_box = {{-5.5, -5.5}, {5.5, 5.5}},
-    draw_entity_info_icon_background = false,
     match_animation_speed_to_activity = false,
     module_specification = {
         module_slots = 6

--- a/prototypes/buildings/scrondrix-pen-mk02.lua
+++ b/prototypes/buildings/scrondrix-pen-mk02.lua
@@ -41,7 +41,6 @@ ENTITY {
     dying_explosion = "big-explosion",
     collision_box = {{-5.2, -5.2}, {5.2, 5.2}},
     selection_box = {{-5.5, -5.5}, {5.5, 5.5}},
-    draw_entity_info_icon_background = false,
     match_animation_speed_to_activity = false,
     module_specification = {
         module_slots = 12

--- a/prototypes/buildings/scrondrix-pen-mk03.lua
+++ b/prototypes/buildings/scrondrix-pen-mk03.lua
@@ -41,7 +41,6 @@ ENTITY {
     dying_explosion = "big-explosion",
     collision_box = {{-5.2, -5.2}, {5.2, 5.2}},
     selection_box = {{-5.5, -5.5}, {5.5, 5.5}},
-    draw_entity_info_icon_background = false,
     match_animation_speed_to_activity = false,
     module_specification = {
         module_slots = 18

--- a/prototypes/buildings/scrondrix-pen-mk04.lua
+++ b/prototypes/buildings/scrondrix-pen-mk04.lua
@@ -41,7 +41,6 @@ ENTITY {
     dying_explosion = "big-explosion",
     collision_box = {{-5.2, -5.2}, {5.2, 5.2}},
     selection_box = {{-5.5, -5.5}, {5.5, 5.5}},
-    draw_entity_info_icon_background = false,
     match_animation_speed_to_activity = false,
     module_specification = {
         module_slots = 24

--- a/prototypes/buildings/seaweed-crop-mk01.lua
+++ b/prototypes/buildings/seaweed-crop-mk01.lua
@@ -40,7 +40,6 @@ ENTITY {
     dying_explosion = "big-explosion",
     collision_box = {{-6.2, -6.2}, {6.2, 6.2}},
     selection_box = {{-6.5, -6.5}, {6.5, 6.5}},
-    draw_entity_info_icon_background = false,
     match_animation_speed_to_activity = false,
     module_specification = {
         module_slots = 10

--- a/prototypes/buildings/seaweed-crop-mk02.lua
+++ b/prototypes/buildings/seaweed-crop-mk02.lua
@@ -40,7 +40,6 @@ ENTITY {
     dying_explosion = "big-explosion",
     collision_box = {{-6.2, -6.2}, {6.2, 6.2}},
     selection_box = {{-6.5, -6.5}, {6.5, 6.5}},
-    draw_entity_info_icon_background = false,
     match_animation_speed_to_activity = false,
     module_specification = {
         module_slots = 20

--- a/prototypes/buildings/seaweed-crop-mk03.lua
+++ b/prototypes/buildings/seaweed-crop-mk03.lua
@@ -40,7 +40,6 @@ ENTITY {
     dying_explosion = "big-explosion",
     collision_box = {{-6.2, -6.2}, {6.2, 6.2}},
     selection_box = {{-6.5, -6.5}, {6.5, 6.5}},
-    draw_entity_info_icon_background = false,
     match_animation_speed_to_activity = false,
     module_specification = {
         module_slots = 30

--- a/prototypes/buildings/seaweed-crop-mk04.lua
+++ b/prototypes/buildings/seaweed-crop-mk04.lua
@@ -40,7 +40,6 @@ ENTITY {
     dying_explosion = "big-explosion",
     collision_box = {{-6.2, -6.2}, {6.2, 6.2}},
     selection_box = {{-6.5, -6.5}, {6.5, 6.5}},
-    draw_entity_info_icon_background = false,
     match_animation_speed_to_activity = false,
     module_specification = {
         module_slots = 40

--- a/prototypes/buildings/slaughterhouse-mk01.lua
+++ b/prototypes/buildings/slaughterhouse-mk01.lua
@@ -42,7 +42,6 @@ ENTITY {
     dying_explosion = "big-explosion",
     collision_box = {{-5.1, -5.1}, {5.1, 5.1}},
     selection_box = {{-5.5, -5.5}, {5.5, 5.5}},
-    draw_entity_info_icon_background = false,
     match_animation_speed_to_activity = false,
     module_specification = {
         module_slots = 1

--- a/prototypes/buildings/slaughterhouse-mk02.lua
+++ b/prototypes/buildings/slaughterhouse-mk02.lua
@@ -42,7 +42,6 @@ ENTITY {
     dying_explosion = "big-explosion",
     collision_box = {{-5.1, -5.1}, {5.1, 5.1}},
     selection_box = {{-5.5, -5.5}, {5.5, 5.5}},
-    draw_entity_info_icon_background = false,
     match_animation_speed_to_activity = false,
     module_specification = {
         module_slots = 2

--- a/prototypes/buildings/slaughterhouse-mk03.lua
+++ b/prototypes/buildings/slaughterhouse-mk03.lua
@@ -41,7 +41,6 @@ ENTITY {
     dying_explosion = "big-explosion",
     collision_box = {{-5.1, -5.1}, {5.1, 5.1}},
     selection_box = {{-5.5, -5.5}, {5.5, 5.5}},
-    draw_entity_info_icon_background = false,
     match_animation_speed_to_activity = false,
     module_specification = {
         module_slots = 3

--- a/prototypes/buildings/slaughterhouse-mk04.lua
+++ b/prototypes/buildings/slaughterhouse-mk04.lua
@@ -41,7 +41,6 @@ ENTITY {
     dying_explosion = "big-explosion",
     collision_box = {{-5.1, -5.1}, {5.1, 5.1}},
     selection_box = {{-5.5, -5.5}, {5.5, 5.5}},
-    draw_entity_info_icon_background = false,
     match_animation_speed_to_activity = false,
     module_specification = {
         module_slots = 4

--- a/prototypes/buildings/space/space-arthurian-pen-mk01.lua
+++ b/prototypes/buildings/space/space-arthurian-pen-mk01.lua
@@ -43,7 +43,6 @@ ENTITY {
     dying_explosion = "big-explosion",
     collision_box = {{-4.8, -4.8}, {4.8, 4.8}},
     selection_box = {{-5.0, -5.0}, {5.0, 5.0}},
-    draw_entity_info_icon_background = false,
     match_animation_speed_to_activity = false,
     module_specification = {
         module_slots = 8

--- a/prototypes/buildings/space/space-bhoddos-culture-mk01.lua
+++ b/prototypes/buildings/space/space-bhoddos-culture-mk01.lua
@@ -44,7 +44,6 @@ ENTITY {
     dying_explosion = "big-explosion",
     collision_box = {{-5.3, -5.3}, {5.3, 5.3}},
     selection_box = {{-5.5, -5.5}, {5.5, 5.5}},
-    draw_entity_info_icon_background = false,
     match_animation_speed_to_activity = false,
     module_specification = {
         module_slots = 1

--- a/prototypes/buildings/space/space-cridren-enclosure-mk01.lua
+++ b/prototypes/buildings/space/space-cridren-enclosure-mk01.lua
@@ -42,7 +42,6 @@ ENTITY {
     dying_explosion = "big-explosion",
     collision_box = {{-4.8, -4.8}, {4.8, 4.8}},
     selection_box = {{-5.0, -5.0}, {5.0, 5.0}},
-    draw_entity_info_icon_background = false,
     match_animation_speed_to_activity = false,
     module_specification = {
         module_slots = 1

--- a/prototypes/buildings/space/space-dingrits-mk01.lua
+++ b/prototypes/buildings/space/space-dingrits-mk01.lua
@@ -44,7 +44,6 @@ ENTITY {
     collision_box = {{-6.8, -6.8}, {6.8, 6.8}},
     selection_box = {{-7.0, -7.0}, {7.0, 7.0}},
     collision_mask = {'ground-tile','water-tile','layer-14'},
-    --draw_entity_info_icon_background = false,
     match_animation_speed_to_activity = false,
     module_specification = {
         module_slots = 20

--- a/prototypes/buildings/space/space-ez-ranch-mk01.lua
+++ b/prototypes/buildings/space/space-ez-ranch-mk01.lua
@@ -43,7 +43,6 @@ ENTITY {
     dying_explosion = "big-explosion",
     collision_box = {{-4.8, -4.8}, {4.8, 4.8}},
     selection_box = {{-5.0, -5.0}, {5.0, 5.0}},
-    draw_entity_info_icon_background = false,
     match_animation_speed_to_activity = false,
     module_specification = {
         module_slots = 20

--- a/prototypes/buildings/space/space-fish-farm-mk01.lua
+++ b/prototypes/buildings/space/space-fish-farm-mk01.lua
@@ -46,7 +46,6 @@ ENTITY {
     dying_explosion = "big-explosion",
     collision_box = {{-5.1, -5.1}, {5.1, 5.1}},
     selection_box = {{-5.5, -5.5}, {5.5, 5.5}},
-    draw_entity_info_icon_background = false,
     match_animation_speed_to_activity = false,
     module_specification = {
         module_slots = 7

--- a/prototypes/buildings/space/space-fwf-mk01.lua
+++ b/prototypes/buildings/space/space-fwf-mk01.lua
@@ -42,7 +42,6 @@ ENTITY {
     dying_explosion = "big-explosion",
     collision_box = {{-5.1, -5.1}, {5.1, 5.1}},
     selection_box = {{-5.5, -5.5}, {5.5, 5.5}},
-    draw_entity_info_icon_background = false,
     match_animation_speed_to_activity = false,
     module_specification = {
         module_slots = 25

--- a/prototypes/buildings/space/space-grod-swamp-mk01.lua
+++ b/prototypes/buildings/space/space-grod-swamp-mk01.lua
@@ -46,7 +46,6 @@ ENTITY {
     dying_explosion = "big-explosion",
     collision_box = {{-5.2, -5.2}, {5.2, 5.2}},
     selection_box = {{-5.5, -5.5}, {5.5, 5.5}},
-    --draw_entity_info_icon_background = false,
     match_animation_speed_to_activity = false,
     module_specification = {
         module_slots = 7

--- a/prototypes/buildings/space/space-moss-farm-mk01.lua
+++ b/prototypes/buildings/space/space-moss-farm-mk01.lua
@@ -43,7 +43,6 @@ ENTITY {
     dying_explosion = "big-explosion",
     collision_box = {{-2.9, -2.9}, {2.9, 2.9}},
     selection_box = {{-3.0, -3.0}, {3.0, 3.0}},
-    draw_entity_info_icon_background = false,
     match_animation_speed_to_activity = false,
     module_specification = {
         module_slots = 15

--- a/prototypes/buildings/space/space-mukmoux-pasture-mk01.lua
+++ b/prototypes/buildings/space/space-mukmoux-pasture-mk01.lua
@@ -42,7 +42,6 @@ ENTITY {
     dying_explosion = "big-explosion",
     collision_box = {{-7.2, -7.2}, {7.2, 7.2}},
     selection_box = {{-7.5, -7.5}, {7.5, 7.5}},
-    draw_entity_info_icon_background = false,
     match_animation_speed_to_activity = false,
     module_specification = {
         module_slots = 8

--- a/prototypes/buildings/space/space-navens-culture-mk01.lua
+++ b/prototypes/buildings/space/space-navens-culture-mk01.lua
@@ -44,7 +44,6 @@ ENTITY {
     dying_explosion = "big-explosion",
     collision_box = {{-4.8, -4.8}, {4.8, 4.8}},
     selection_box = {{-5.0, -5.0}, {5.0, 5.0}},
-    draw_entity_info_icon_background = false,
     match_animation_speed_to_activity = false,
     module_specification = {
         module_slots = 4

--- a/prototypes/buildings/space/space-phadai-enclosure-mk01.lua
+++ b/prototypes/buildings/space/space-phadai-enclosure-mk01.lua
@@ -43,7 +43,6 @@ ENTITY {
     dying_explosion = "big-explosion",
     collision_box = {{-6.2, -6.2}, {6.2, 6.2}},
     selection_box = {{-6.5, -6.5}, {6.5, 6.5}},
-    --draw_entity_info_icon_background = false,
     match_animation_speed_to_activity = false,
     module_specification = {
         module_slots = 5

--- a/prototypes/buildings/space/space-phagnot-corral-mk01.lua
+++ b/prototypes/buildings/space/space-phagnot-corral-mk01.lua
@@ -43,7 +43,6 @@ ENTITY {
     dying_explosion = "big-explosion",
     collision_box = {{-5.8, -5.8}, {5.8, 5.8}},
     selection_box = {{-6.0, -6.0}, {6.0, 6.0}},
-    draw_entity_info_icon_background = false,
     match_animation_speed_to_activity = false,
     module_specification = {
         module_slots = 10

--- a/prototypes/buildings/space/space-ralesia-plantation-mk01.lua
+++ b/prototypes/buildings/space/space-ralesia-plantation-mk01.lua
@@ -72,7 +72,6 @@ ENTITY {
     dying_explosion = "medium-explosion",
     collision_box = {{-3.2, -3.2}, {3.2, 3.2}},
     selection_box = {{-3.5, -3.5}, {3.5, 3.5}},
-    draw_entity_info_icon_background = false,
     match_animation_speed_to_activity = false,
     module_specification = {
         module_slots = 12

--- a/prototypes/buildings/space/space-rennea-plantation-mk01.lua
+++ b/prototypes/buildings/space/space-rennea-plantation-mk01.lua
@@ -46,7 +46,6 @@ ENTITY {
     dying_explosion = "big-explosion",
     collision_box = {{-6.2, -6.2}, {6.2, 6.2}},
     selection_box = {{-6.5, -6.5}, {6.5, 6.5}},
-    --draw_entity_info_icon_background = false,
     match_animation_speed_to_activity = false,
     module_specification = {
         module_slots = 30

--- a/prototypes/buildings/space/space-sap-extractor-mk01.lua
+++ b/prototypes/buildings/space/space-sap-extractor-mk01.lua
@@ -43,7 +43,6 @@ ENTITY {
     dying_explosion = "big-explosion",
     collision_box = {{-2.4, -2.4}, {2.4, 2.4}},
     selection_box = {{-2.5, -2.5}, {2.5, 2.5}},
-    draw_entity_info_icon_background = false,
     match_animation_speed_to_activity = false,
     fixed_recipe = "sap-01",
     module_specification = {

--- a/prototypes/buildings/space/space-scrondrix-pen-mk01.lua
+++ b/prototypes/buildings/space/space-scrondrix-pen-mk01.lua
@@ -43,7 +43,6 @@ ENTITY {
     dying_explosion = "big-explosion",
     collision_box = {{-5.2, -5.2}, {5.2, 5.2}},
     selection_box = {{-5.5, -5.5}, {5.5, 5.5}},
-    draw_entity_info_icon_background = false,
     match_animation_speed_to_activity = false,
     module_specification = {
         module_slots = 6

--- a/prototypes/buildings/space/space-seaweed-crop-mk01.lua
+++ b/prototypes/buildings/space/space-seaweed-crop-mk01.lua
@@ -42,7 +42,6 @@ ENTITY {
     dying_explosion = "big-explosion",
     collision_box = {{-6.2, -6.2}, {6.2, 6.2}},
     selection_box = {{-6.5, -6.5}, {6.5, 6.5}},
-    draw_entity_info_icon_background = false,
     match_animation_speed_to_activity = false,
     module_specification = {
         module_slots = 10

--- a/prototypes/buildings/space/space-sponge-culture-mk01.lua
+++ b/prototypes/buildings/space/space-sponge-culture-mk01.lua
@@ -45,7 +45,6 @@ ENTITY {
     dying_explosion = "big-explosion",
     collision_box = {{-5.2, -5.2}, {5.2, 5.2}},
     selection_box = {{-5.5, -5.5}, {5.5, 5.5}},
-    draw_entity_info_icon_background = false,
     match_animation_speed_to_activity = false,
     module_specification = {
         module_slots = 8

--- a/prototypes/buildings/space/space-trits-reef-mk01.lua
+++ b/prototypes/buildings/space/space-trits-reef-mk01.lua
@@ -43,7 +43,6 @@ ENTITY {
     dying_explosion = "big-explosion",
     collision_box = {{-4.8, -4.8}, {4.8, 4.8}},
     selection_box = {{-5.0, -5.0}, {5.0, 5.0}},
-    draw_entity_info_icon_background = false,
     match_animation_speed_to_activity = false,
     module_specification = {
         module_slots = 1

--- a/prototypes/buildings/space/space-tuuphra-plantation-mk01.lua
+++ b/prototypes/buildings/space/space-tuuphra-plantation-mk01.lua
@@ -43,7 +43,6 @@ ENTITY {
     dying_explosion = "big-explosion",
     collision_box = {{-4.2, -4.2}, {4.2, 4.2}},
     selection_box = {{-4.5, -4.5}, {4.5, 4.5}},
-    draw_entity_info_icon_background = false,
     match_animation_speed_to_activity = false,
     module_specification = {
         module_slots = 5

--- a/prototypes/buildings/space/space-ulric-corral-mk01.lua
+++ b/prototypes/buildings/space/space-ulric-corral-mk01.lua
@@ -45,7 +45,6 @@ ENTITY {
     module_specification = {
         module_slots = 8,
     },
-    draw_entity_info_icon_background = false,
     match_animation_speed_to_activity = false,
     allowed_effects = {"speed","productivity",'consumption','pollution'},
     crafting_categories = {"ulric"},

--- a/prototypes/buildings/space/space-vonix-den-mk01.lua
+++ b/prototypes/buildings/space/space-vonix-den-mk01.lua
@@ -44,7 +44,6 @@ ENTITY {
     dying_explosion = "big-explosion",
     collision_box = {{-4.8, -4.8}, {4.8, 4.8}},
     selection_box = {{-5.0, -5.0}, {5.0, 5.0}},
-    draw_entity_info_icon_background = false,
     match_animation_speed_to_activity = false,
     module_specification = {
         module_slots = 1

--- a/prototypes/buildings/space/space-vrauks-paddock-mk01.lua
+++ b/prototypes/buildings/space/space-vrauks-paddock-mk01.lua
@@ -42,7 +42,6 @@ ENTITY {
     dying_explosion = "big-explosion",
     collision_box = {{-6.1, -6.1}, {6.1, 6.1}},
     selection_box = {{-6.5, -6.5}, {6.5, 6.5}},
-    draw_entity_info_icon_background = false,
     match_animation_speed_to_activity = false,
     module_specification = {
         module_slots = 10

--- a/prototypes/buildings/space/space-xenopen-mk01.lua
+++ b/prototypes/buildings/space/space-xenopen-mk01.lua
@@ -43,7 +43,6 @@ ENTITY {
     dying_explosion = "big-explosion",
     collision_box = {{-6.3, -6.3}, {6.3, 6.3}},
     selection_box = {{-6.5, -6.5}, {6.5, 6.5}},
-    --draw_entity_info_icon_background = false,
     match_animation_speed_to_activity = false,
     module_specification = {
         module_slots = 9

--- a/prototypes/buildings/space/space-yaedols-culture-mk01.lua
+++ b/prototypes/buildings/space/space-yaedols-culture-mk01.lua
@@ -44,7 +44,6 @@ ENTITY {
     dying_explosion = "big-explosion",
     collision_box = {{-5.3, -5.3}, {5.3, 5.3}},
     selection_box = {{-5.5, -5.5}, {5.5, 5.5}},
-    draw_entity_info_icon_background = false,
     match_animation_speed_to_activity = false,
     module_specification = {
         module_slots = 3

--- a/prototypes/buildings/space/space-yotoi-aloe-orchard-mk01.lua
+++ b/prototypes/buildings/space/space-yotoi-aloe-orchard-mk01.lua
@@ -43,7 +43,6 @@ ENTITY {
     dying_explosion = "big-explosion",
     collision_box = {{-5.2, -5.2}, {5.2, 5.2}},
     selection_box = {{-5.5, -5.5}, {5.5, 5.5}},
-    draw_entity_info_icon_background = false,
     match_animation_speed_to_activity = false,
     module_specification = {
         module_slots = 33

--- a/prototypes/buildings/sponge-culture-mk01.lua
+++ b/prototypes/buildings/sponge-culture-mk01.lua
@@ -43,7 +43,6 @@ ENTITY {
     dying_explosion = "big-explosion",
     collision_box = {{-5.2, -5.2}, {5.2, 5.2}},
     selection_box = {{-5.5, -5.5}, {5.5, 5.5}},
-    draw_entity_info_icon_background = false,
     match_animation_speed_to_activity = false,
     module_specification = {
         module_slots = 8

--- a/prototypes/buildings/sponge-culture-mk02.lua
+++ b/prototypes/buildings/sponge-culture-mk02.lua
@@ -42,7 +42,6 @@ ENTITY {
     dying_explosion = "big-explosion",
     collision_box = {{-5.2, -5.2}, {5.2, 5.2}},
     selection_box = {{-5.5, -5.5}, {5.5, 5.5}},
-    draw_entity_info_icon_background = false,
     match_animation_speed_to_activity = false,
     module_specification = {
         module_slots = 16

--- a/prototypes/buildings/sponge-culture-mk03.lua
+++ b/prototypes/buildings/sponge-culture-mk03.lua
@@ -40,7 +40,6 @@ ENTITY {
     dying_explosion = "big-explosion",
     collision_box = {{-5.2, -5.2}, {5.2, 5.2}},
     selection_box = {{-5.5, -5.5}, {5.5, 5.5}},
-    draw_entity_info_icon_background = false,
     match_animation_speed_to_activity = false,
     module_specification = {
         module_slots = 24

--- a/prototypes/buildings/sponge-culture-mk04.lua
+++ b/prototypes/buildings/sponge-culture-mk04.lua
@@ -40,7 +40,6 @@ ENTITY {
     dying_explosion = "big-explosion",
     collision_box = {{-5.2, -5.2}, {5.2, 5.2}},
     selection_box = {{-5.5, -5.5}, {5.5, 5.5}},
-    draw_entity_info_icon_background = false,
     match_animation_speed_to_activity = false,
     module_specification = {
         module_slots = 32

--- a/prototypes/buildings/trits-reef-mk01.lua
+++ b/prototypes/buildings/trits-reef-mk01.lua
@@ -41,7 +41,6 @@ ENTITY {
     dying_explosion = "big-explosion",
     collision_box = {{-4.8, -4.8}, {4.8, 4.8}},
     selection_box = {{-5.0, -5.0}, {5.0, 5.0}},
-    draw_entity_info_icon_background = false,
     match_animation_speed_to_activity = false,
     module_specification = {
         module_slots = 1

--- a/prototypes/buildings/trits-reef-mk02.lua
+++ b/prototypes/buildings/trits-reef-mk02.lua
@@ -42,7 +42,6 @@ ENTITY {
     dying_explosion = "big-explosion",
     collision_box = {{-4.8, -4.8}, {4.8, 4.8}},
     selection_box = {{-5.0, -5.0}, {5.0, 5.0}},
-    draw_entity_info_icon_background = false,
     match_animation_speed_to_activity = false,
     module_specification = {
         module_slots = 2

--- a/prototypes/buildings/trits-reef-mk03.lua
+++ b/prototypes/buildings/trits-reef-mk03.lua
@@ -40,7 +40,6 @@ ENTITY {
     dying_explosion = "big-explosion",
     collision_box = {{-4.8, -4.8}, {4.8, 4.8}},
     selection_box = {{-5.0, -5.0}, {5.0, 5.0}},
-    draw_entity_info_icon_background = false,
     match_animation_speed_to_activity = false,
     module_specification = {
         module_slots = 3

--- a/prototypes/buildings/trits-reef-mk04.lua
+++ b/prototypes/buildings/trits-reef-mk04.lua
@@ -41,7 +41,6 @@ ENTITY {
     dying_explosion = "big-explosion",
     collision_box = {{-4.8, -4.8}, {4.8, 4.8}},
     selection_box = {{-5.0, -5.0}, {5.0, 5.0}},
-    draw_entity_info_icon_background = false,
     match_animation_speed_to_activity = false,
     module_specification = {
         module_slots = 4

--- a/prototypes/buildings/tuuphra-plantation-mk01.lua
+++ b/prototypes/buildings/tuuphra-plantation-mk01.lua
@@ -41,7 +41,6 @@ ENTITY {
     dying_explosion = "big-explosion",
     collision_box = {{-4.2, -4.2}, {4.2, 4.2}},
     selection_box = {{-4.5, -4.5}, {4.5, 4.5}},
-    draw_entity_info_icon_background = false,
     match_animation_speed_to_activity = false,
     module_specification = {
         module_slots = 5

--- a/prototypes/buildings/tuuphra-plantation-mk02.lua
+++ b/prototypes/buildings/tuuphra-plantation-mk02.lua
@@ -41,7 +41,6 @@ ENTITY {
     dying_explosion = "big-explosion",
     collision_box = {{-4.2, -4.2}, {4.2, 4.2}},
     selection_box = {{-4.5, -4.5}, {4.5, 4.5}},
-    draw_entity_info_icon_background = false,
     match_animation_speed_to_activity = false,
     module_specification = {
         module_slots = 10

--- a/prototypes/buildings/tuuphra-plantation-mk03.lua
+++ b/prototypes/buildings/tuuphra-plantation-mk03.lua
@@ -40,7 +40,6 @@ ENTITY {
     dying_explosion = "big-explosion",
     collision_box = {{-4.2, -4.2}, {4.2, 4.2}},
     selection_box = {{-4.5, -4.5}, {4.5, 4.5}},
-    draw_entity_info_icon_background = false,
     match_animation_speed_to_activity = false,
     module_specification = {
         module_slots = 20

--- a/prototypes/buildings/tuuphra-plantation-mk04.lua
+++ b/prototypes/buildings/tuuphra-plantation-mk04.lua
@@ -40,7 +40,6 @@ ENTITY {
     dying_explosion = "big-explosion",
     collision_box = {{-4.2, -4.2}, {4.2, 4.2}},
     selection_box = {{-4.5, -4.5}, {4.5, 4.5}},
-    draw_entity_info_icon_background = false,
     match_animation_speed_to_activity = false,
     module_specification = {
         module_slots = 40

--- a/prototypes/buildings/ulric-corral-mk01.lua
+++ b/prototypes/buildings/ulric-corral-mk01.lua
@@ -43,7 +43,6 @@ ENTITY {
     module_specification = {
         module_slots = 8,
     },
-    draw_entity_info_icon_background = false,
     match_animation_speed_to_activity = false,
     allowed_effects = {"speed","productivity",'consumption','pollution'},
     crafting_categories = {"ulric"},

--- a/prototypes/buildings/ulric-corral-mk02.lua
+++ b/prototypes/buildings/ulric-corral-mk02.lua
@@ -44,7 +44,6 @@ ENTITY {
     module_specification = {
         module_slots = 16,
     },
-    draw_entity_info_icon_background = false,
     match_animation_speed_to_activity = false,
     allowed_effects = {"speed","productivity",'consumption','pollution'},
     crafting_categories = {"ulric"},

--- a/prototypes/buildings/ulric-corral-mk03.lua
+++ b/prototypes/buildings/ulric-corral-mk03.lua
@@ -44,7 +44,6 @@ ENTITY {
     module_specification = {
         module_slots = 24,
     },
-    draw_entity_info_icon_background = false,
     match_animation_speed_to_activity = false,
     allowed_effects = {"speed","productivity",'consumption','pollution'},
     crafting_categories = {"ulric"},

--- a/prototypes/buildings/ulric-corral-mk04.lua
+++ b/prototypes/buildings/ulric-corral-mk04.lua
@@ -44,7 +44,6 @@ ENTITY {
     module_specification = {
         module_slots = 32,
     },
-    draw_entity_info_icon_background = false,
     match_animation_speed_to_activity = false,
     allowed_effects = {"speed","productivity",'consumption','pollution'},
     crafting_categories = {"ulric"},

--- a/prototypes/buildings/vonix-den-mk01.lua
+++ b/prototypes/buildings/vonix-den-mk01.lua
@@ -42,7 +42,6 @@ ENTITY {
     dying_explosion = "big-explosion",
     collision_box = {{-4.8, -4.8}, {4.8, 4.8}},
     selection_box = {{-5.0, -5.0}, {5.0, 5.0}},
-    draw_entity_info_icon_background = false,
     match_animation_speed_to_activity = false,
     module_specification = {
         module_slots = 1

--- a/prototypes/buildings/vonix-den-mk02.lua
+++ b/prototypes/buildings/vonix-den-mk02.lua
@@ -42,7 +42,6 @@ ENTITY {
     dying_explosion = "big-explosion",
     collision_box = {{-4.8, -4.8}, {4.8, 4.8}},
     selection_box = {{-5.0, -5.0}, {5.0, 5.0}},
-    draw_entity_info_icon_background = false,
     match_animation_speed_to_activity = false,
     module_specification = {
         module_slots = 2

--- a/prototypes/buildings/vonix-den-mk03.lua
+++ b/prototypes/buildings/vonix-den-mk03.lua
@@ -41,7 +41,6 @@ ENTITY {
     dying_explosion = "big-explosion",
     collision_box = {{-4.8, -4.8}, {4.8, 4.8}},
     selection_box = {{-5.0, -5.0}, {5.0, 5.0}},
-    draw_entity_info_icon_background = false,
     match_animation_speed_to_activity = false,
     module_specification = {
         module_slots = 3

--- a/prototypes/buildings/vrauks-paddock-mk01.lua
+++ b/prototypes/buildings/vrauks-paddock-mk01.lua
@@ -41,7 +41,6 @@ ENTITY {
     dying_explosion = "big-explosion",
     collision_box = {{-6.1, -6.1}, {6.1, 6.1}},
     selection_box = {{-6.5, -6.5}, {6.5, 6.5}},
-    draw_entity_info_icon_background = false,
     match_animation_speed_to_activity = false,
     module_specification = {
         module_slots = 10

--- a/prototypes/buildings/vrauks-paddock-mk02.lua
+++ b/prototypes/buildings/vrauks-paddock-mk02.lua
@@ -41,7 +41,6 @@ ENTITY {
     dying_explosion = "big-explosion",
     collision_box = {{-6.1, -6.1}, {6.1, 6.1}},
     selection_box = {{-6.5, -6.5}, {6.5, 6.5}},
-    draw_entity_info_icon_background = false,
     match_animation_speed_to_activity = false,
     module_specification = {
         module_slots = 30

--- a/prototypes/buildings/vrauks-paddock-mk03.lua
+++ b/prototypes/buildings/vrauks-paddock-mk03.lua
@@ -41,7 +41,6 @@ ENTITY {
     dying_explosion = "big-explosion",
     collision_box = {{-6.1, -6.1}, {6.1, 6.1}},
     selection_box = {{-6.5, -6.5}, {6.5, 6.5}},
-    draw_entity_info_icon_background = false,
     match_animation_speed_to_activity = false,
     module_specification = {
         module_slots = 90

--- a/prototypes/buildings/vrauks-paddock-mk04.lua
+++ b/prototypes/buildings/vrauks-paddock-mk04.lua
@@ -41,7 +41,6 @@ ENTITY {
     dying_explosion = "big-explosion",
     collision_box = {{-6.1, -6.1}, {6.1, 6.1}},
     selection_box = {{-6.5, -6.5}, {6.5, 6.5}},
-    draw_entity_info_icon_background = false,
     match_animation_speed_to_activity = false,
     module_specification = {
         module_slots = 270

--- a/prototypes/buildings/xenopen-mk01.lua
+++ b/prototypes/buildings/xenopen-mk01.lua
@@ -41,7 +41,6 @@ ENTITY {
     dying_explosion = "big-explosion",
     collision_box = {{-6.3, -6.3}, {6.3, 6.3}},
     selection_box = {{-6.5, -6.5}, {6.5, 6.5}},
-    --draw_entity_info_icon_background = false,
     match_animation_speed_to_activity = false,
     module_specification = {
         module_slots = 9

--- a/prototypes/buildings/xenopen-mk02.lua
+++ b/prototypes/buildings/xenopen-mk02.lua
@@ -41,7 +41,6 @@ ENTITY {
     dying_explosion = "big-explosion",
     collision_box = {{-6.3, -6.3}, {6.3, 6.3}},
     selection_box = {{-6.5, -6.5}, {6.5, 6.5}},
-    --draw_entity_info_icon_background = false,
     match_animation_speed_to_activity = false,
     module_specification = {
         module_slots = 18

--- a/prototypes/buildings/xenopen-mk03.lua
+++ b/prototypes/buildings/xenopen-mk03.lua
@@ -41,7 +41,6 @@ ENTITY {
     dying_explosion = "big-explosion",
     collision_box = {{-6.3, -6.3}, {6.3, 6.3}},
     selection_box = {{-6.5, -6.5}, {6.5, 6.5}},
-    --draw_entity_info_icon_background = false,
     match_animation_speed_to_activity = false,
     module_specification = {
         module_slots = 27

--- a/prototypes/buildings/xenopen-mk04.lua
+++ b/prototypes/buildings/xenopen-mk04.lua
@@ -41,7 +41,6 @@ ENTITY {
     dying_explosion = "big-explosion",
     collision_box = {{-6.3, -6.3}, {6.3, 6.3}},
     selection_box = {{-6.5, -6.5}, {6.5, 6.5}},
-    --draw_entity_info_icon_background = false,
     match_animation_speed_to_activity = false,
     module_specification = {
         module_slots = 36

--- a/prototypes/buildings/yaedols-culture-mk01.lua
+++ b/prototypes/buildings/yaedols-culture-mk01.lua
@@ -42,7 +42,6 @@ ENTITY {
     dying_explosion = "big-explosion",
     collision_box = {{-5.3, -5.3}, {5.3, 5.3}},
     selection_box = {{-5.5, -5.5}, {5.5, 5.5}},
-    draw_entity_info_icon_background = false,
     match_animation_speed_to_activity = false,
     module_specification = {
         module_slots = 3

--- a/prototypes/buildings/yaedols-culture-mk02.lua
+++ b/prototypes/buildings/yaedols-culture-mk02.lua
@@ -42,7 +42,6 @@ ENTITY {
     dying_explosion = "big-explosion",
     collision_box = {{-5.3, -5.3}, {5.3, 5.3}},
     selection_box = {{-5.5, -5.5}, {5.5, 5.5}},
-    draw_entity_info_icon_background = false,
     match_animation_speed_to_activity = false,
     module_specification = {
         module_slots = 5

--- a/prototypes/buildings/yaedols-culture-mk03.lua
+++ b/prototypes/buildings/yaedols-culture-mk03.lua
@@ -42,7 +42,6 @@ ENTITY {
     dying_explosion = "big-explosion",
     collision_box = {{-5.3, -5.3}, {5.3, 5.3}},
     selection_box = {{-5.5, -5.5}, {5.5, 5.5}},
-    draw_entity_info_icon_background = false,
     match_animation_speed_to_activity = false,
     module_specification = {
         module_slots = 8

--- a/prototypes/buildings/yaedols-culture-mk04.lua
+++ b/prototypes/buildings/yaedols-culture-mk04.lua
@@ -42,7 +42,6 @@ ENTITY {
     dying_explosion = "big-explosion",
     collision_box = {{-5.3, -5.3}, {5.3, 5.3}},
     selection_box = {{-5.5, -5.5}, {5.5, 5.5}},
-    draw_entity_info_icon_background = false,
     match_animation_speed_to_activity = false,
     module_specification = {
         module_slots = 10

--- a/prototypes/buildings/yotoi-aloe-orchard-mk01.lua
+++ b/prototypes/buildings/yotoi-aloe-orchard-mk01.lua
@@ -41,7 +41,6 @@ ENTITY {
     dying_explosion = "big-explosion",
     collision_box = {{-5.2, -5.2}, {5.2, 5.2}},
     selection_box = {{-5.5, -5.5}, {5.5, 5.5}},
-    draw_entity_info_icon_background = false,
     match_animation_speed_to_activity = false,
     module_specification = {
         module_slots = 33

--- a/prototypes/buildings/yotoi-aloe-orchard-mk02.lua
+++ b/prototypes/buildings/yotoi-aloe-orchard-mk02.lua
@@ -41,7 +41,6 @@ ENTITY {
     dying_explosion = "big-explosion",
     collision_box = {{-5.2, -5.2}, {5.2, 5.2}},
     selection_box = {{-5.5, -5.5}, {5.5, 5.5}},
-    draw_entity_info_icon_background = false,
     match_animation_speed_to_activity = false,
     module_specification = {
         module_slots = 66

--- a/prototypes/buildings/yotoi-aloe-orchard-mk03.lua
+++ b/prototypes/buildings/yotoi-aloe-orchard-mk03.lua
@@ -40,7 +40,6 @@ ENTITY {
     dying_explosion = "big-explosion",
     collision_box = {{-5.2, -5.2}, {5.2, 5.2}},
     selection_box = {{-5.5, -5.5}, {5.5, 5.5}},
-    draw_entity_info_icon_background = false,
     match_animation_speed_to_activity = false,
     module_specification = {
         module_slots = 99

--- a/prototypes/buildings/yotoi-aloe-orchard-mk04.lua
+++ b/prototypes/buildings/yotoi-aloe-orchard-mk04.lua
@@ -40,7 +40,6 @@ ENTITY {
     dying_explosion = "big-explosion",
     collision_box = {{-5.2, -5.2}, {5.2, 5.2}},
     selection_box = {{-5.5, -5.5}, {5.5, 5.5}},
-    draw_entity_info_icon_background = false,
     match_animation_speed_to_activity = false,
     module_specification = {
         module_slots = 132


### PR DESCRIPTION
Defaults to true, and alt-mode becomes much less usable without it enabled

edited to add screenshot, the flag is responsible for the drop shadow behind the recipe icon in alt-mode
![image](https://user-images.githubusercontent.com/65210810/140877871-609c5a0a-fa03-47a2-8e0c-efd8b0a21d5b.png)
