### PR TITLE
Collectors and other miners no longer take simik related upgrade modules

### DIFF
--- a/prototypes/buildings/collector-mk02.lua
+++ b/prototypes/buildings/collector-mk02.lua
@@ -47,7 +47,7 @@ ENTITY {
     module_specification = {
         module_slots = 1
     },
-    allowed_effects = {"consumption", "speed", "pollution"},
+    allowed_effects = {"consumption", "speed"},
     mining_speed = 2,
     energy_source = {
         type = "electric",

--- a/prototypes/buildings/collector-mk03.lua
+++ b/prototypes/buildings/collector-mk03.lua
@@ -46,7 +46,7 @@ ENTITY {
     module_specification = {
         module_slots = 1
     },
-    allowed_effects = {"consumption", "speed", "pollution"},
+    allowed_effects = {"consumption", "speed"},
     mining_speed = 3,
     energy_source = {
         type = "electric",

--- a/prototypes/buildings/collector-mk04.lua
+++ b/prototypes/buildings/collector-mk04.lua
@@ -45,7 +45,7 @@ ENTITY {
     module_specification = {
         module_slots = 1
     },
-    allowed_effects = {"consumption", "speed", "pollution"},
+    allowed_effects = {"consumption", "speed"},
     mining_speed = 4,
     energy_source = {
         type = "electric",

--- a/prototypes/buildings/collector.lua
+++ b/prototypes/buildings/collector.lua
@@ -45,7 +45,7 @@ ENTITY {
     module_specification = {
         module_slots = 1
     },
-    allowed_effects = {"consumption", "speed", "pollution"},
+    allowed_effects = {"consumption", "speed"},
     mining_speed = 1,
     energy_source = {
         type = "electric",

--- a/prototypes/upgrades/compost.lua
+++ b/prototypes/upgrades/compost.lua
@@ -42,7 +42,7 @@ local tech_upgrades =
                         consumption = 0.2, --energy usage
                         speed = 0.25, -- machine speed
                         productivity = 0.0, -- productivity. and yes i know you`ll never use this but I`ll make sure it works anyway
-                        pollution = 0.0 -- pollution this machine will produce while running
+                        pollution = 0.1 -- pollution this machine will produce while running
                     },
                 techs_to_lock = -- techs that should be locked and hidden if this tech is researched
                     {

--- a/prototypes/upgrades/simikmetalMK01.lua
+++ b/prototypes/upgrades/simikmetalMK01.lua
@@ -46,7 +46,7 @@ local tech_upgrades =
                         consumption = 0.0, --energy usage
                         speed = 0.0, -- machine speed
                         productivity = 0.0, -- productivity. and yes i know you`ll never use this but I`ll make sure it works anyway
-                        pollution = 0.0 -- pollution this machine will produce while running
+                        pollution = 0.1 -- pollution this machine will produce while running
                     },
                 techs_to_lock = -- techs that should be locked and hidden if this tech is researched
                     {
@@ -79,7 +79,7 @@ local tech_upgrades =
                         consumption = 0.0,
                         speed = 0.0,
                         productivity = 0.0,
-                        pollution = 0.0
+                        pollution = 0.1
                     },
                 techs_to_lock =
                     {
@@ -111,9 +111,9 @@ local tech_upgrades =
                 upgrades =
                     {
                         consumption = 0,
-                        speed = -0.0,
+                        speed = 0.0,
                         productivity = 0.0,
-                        pollution = -0.0
+                        pollution = 0.1
                     },
                 techs_to_lock =
                     {

--- a/prototypes/upgrades/simikmetalMK02.lua
+++ b/prototypes/upgrades/simikmetalMK02.lua
@@ -46,7 +46,7 @@ local tech_upgrades =
                         consumption = 0.0, --energy usage
                         speed = 0.0, -- machine speed
                         productivity = 0.0, -- productivity. and yes i know you`ll never use this but I`ll make sure it works anyway
-                        pollution = 0.0 -- pollution this machine will produce while running
+                        pollution = 0.1 -- pollution this machine will produce while running
                     },
                 techs_to_lock = -- techs that should be locked and hidden if this tech is researched
                     {
@@ -79,7 +79,7 @@ local tech_upgrades =
                         consumption = 0.0,
                         speed = 0.0,
                         productivity = 0.0,
-                        pollution = 0.0
+                        pollution = 0.1
                     },
                 techs_to_lock =
                     {
@@ -111,9 +111,9 @@ local tech_upgrades =
                 upgrades =
                     {
                         consumption = 0,
-                        speed = -0.0,
+                        speed = 0.0,
                         productivity = 0.0,
-                        pollution = -0.0
+                        pollution = 0.1
                     },
                 techs_to_lock =
                     {

--- a/prototypes/upgrades/simikmetalMK03.lua
+++ b/prototypes/upgrades/simikmetalMK03.lua
@@ -47,7 +47,7 @@ local tech_upgrades =
                         consumption = 0.0, --energy usage
                         speed = 0.0, -- machine speed
                         productivity = 0.0, -- productivity. and yes i know you`ll never use this but I`ll make sure it works anyway
-                        pollution = 0.0 -- pollution this machine will produce while running
+                        pollution = 0.1 -- pollution this machine will produce while running
                     },
                 techs_to_lock = -- techs that should be locked and hidden if this tech is researched
                     {
@@ -80,7 +80,7 @@ local tech_upgrades =
                         consumption = 0.0,
                         speed = 0.0,
                         productivity = 0.0,
-                        pollution = 0.0
+                        pollution = 0.1
                     },
                 techs_to_lock =
                     {
@@ -112,9 +112,9 @@ local tech_upgrades =
                 upgrades =
                     {
                         consumption = 0,
-                        speed = -0.0,
+                        speed = 0.0,
                         productivity = 0.0,
-                        pollution = -0.0
+                        pollution = 0.1
                     },
                 techs_to_lock =
                     {

--- a/prototypes/upgrades/simikmetalMK04.lua
+++ b/prototypes/upgrades/simikmetalMK04.lua
@@ -47,7 +47,7 @@ local tech_upgrades =
                         consumption = 0.0, --energy usage
                         speed = 0.0, -- machine speed
                         productivity = 0.0, -- productivity. and yes i know you`ll never use this but I`ll make sure it works anyway
-                        pollution = 0.0 -- pollution this machine will produce while running
+                        pollution = 0.1 -- pollution this machine will produce while running
                     },
                 techs_to_lock = -- techs that should be locked and hidden if this tech is researched
                     {
@@ -80,7 +80,7 @@ local tech_upgrades =
                         consumption = 0.0,
                         speed = 0.0,
                         productivity = 0.0,
-                        pollution = 0.0
+                        pollution = 0.1
                     },
                 techs_to_lock =
                     {
@@ -112,9 +112,9 @@ local tech_upgrades =
                 upgrades =
                     {
                         consumption = 0,
-                        speed = -0.0,
+                        speed = 0.0,
                         productivity = 0.0,
-                        pollution = -0.0
+                        pollution = 0.1
                     },
                 techs_to_lock =
                     {

--- a/prototypes/upgrades/simikmetalMK05.lua
+++ b/prototypes/upgrades/simikmetalMK05.lua
@@ -49,7 +49,7 @@ local tech_upgrades =
                         consumption = 0.0, --energy usage
                         speed = 0.0, -- machine speed
                         productivity = 0.0, -- productivity. and yes i know you`ll never use this but I`ll make sure it works anyway
-                        pollution = 0.0 -- pollution this machine will produce while running
+                        pollution = 0.1 -- pollution this machine will produce while running
                     },
                 techs_to_lock = -- techs that should be locked and hidden if this tech is researched
                     {
@@ -82,7 +82,7 @@ local tech_upgrades =
                         consumption = 0.0,
                         speed = 0.0,
                         productivity = 0.0,
-                        pollution = 0.0
+                        pollution = 0.1
                     },
                 techs_to_lock =
                     {
@@ -114,9 +114,9 @@ local tech_upgrades =
                 upgrades =
                     {
                         consumption = 0,
-                        speed = -0.0,
+                        speed = 0.0,
                         productivity = 0.0,
-                        pollution = -0.0
+                        pollution = 0.1
                     },
                 techs_to_lock =
                     {

--- a/prototypes/upgrades/simikmetalMK06.lua
+++ b/prototypes/upgrades/simikmetalMK06.lua
@@ -49,7 +49,7 @@ local tech_upgrades =
                         consumption = 0.0, --energy usage
                         speed = 0.0, -- machine speed
                         productivity = 0.0, -- productivity. and yes i know you`ll never use this but I`ll make sure it works anyway
-                        pollution = 0.0 -- pollution this machine will produce while running
+                        pollution = 0.1 -- pollution this machine will produce while running
                     },
                 techs_to_lock = -- techs that should be locked and hidden if this tech is researched
                     {
@@ -82,7 +82,7 @@ local tech_upgrades =
                         consumption = 0.0,
                         speed = 0.0,
                         productivity = 0.0,
-                        pollution = 0.0
+                        pollution = 0.1
                     },
                 techs_to_lock =
                     {
@@ -116,7 +116,7 @@ local tech_upgrades =
                         consumption = 0,
                         speed = -0.0,
                         productivity = 0.0,
-                        pollution = -0.0
+                        pollution = 0.1
                     },
                 techs_to_lock =
                     {


### PR DESCRIPTION
This is done by making these modules increase pollution output, and forbidding pollution modules in these miners.

resolves pyanodon/pybugreports#45

I have the changes ready to forbid pollution in all other repositories too, so if this one is accepted (or a comment is made to this effect), I'll make pull requests for those too. I didn't want to spam too many pull requests for this one.