### PR TITLE
Make initial scrondrix loop (barely) positive

### DIFF
--- a/prototypes/recipes/scrondrix/recipes-scrondrix-raising.lua
+++ b/prototypes/recipes/scrondrix/recipes-scrondrix-raising.lua
@@ -23,7 +23,7 @@ FUN.autorecipes {
 				},
 			results =
 				{
-					{name='scrondrix-pup', amount = 4},
+					{name='scrondrix-pup', amount = 5},
 					{name='cage', amount = 2},
 					{name = 'manure', amount = 5},
 				},
@@ -41,7 +41,7 @@ FUN.autorecipes {
 				},
 			results =
 				{
-					{name='scrondrix-pup', add_amount = 2},
+					{name='scrondrix-pup', add_amount = 1},
 					{name = 'manure', add_amount = 3},
 				},
 			crafting_speed = 120,
@@ -219,7 +219,7 @@ FUN.autorecipes {
 				},
 			results =
 				{
-					{name='caged-scrondrix', amount = 4},
+					{name='caged-scrondrix', amount = 5},
 					{name = 'manure', amount = 5},
 				},
 			crafting_speed = 150,


### PR DESCRIPTION
Minimum change to unblock people getting to pysci3

Before: 10 -> 8 at chem, 10 -> 13.33 at py3
![image](https://user-images.githubusercontent.com/49283746/194387693-5c6b0be5-efee-4b54-807f-c3cd41feb0d8.png)

AfterL 10 -> 12.5 at chem, 10 -> 18 at py3
![image](https://user-images.githubusercontent.com/49283746/194388405-20a76819-0c09-4907-b097-2c1a55707c8e.png)

This will get overwritten by shadowglass doing whatever, but it's to make the release functional before then. This maintains progression, the later recipes are still considered better by YAFC