### PR TITLE
Fix farm module tip to appear on time.

### DIFF
--- a/prototypes/tips-and-tricks.lua
+++ b/prototypes/tips-and-tricks.lua
@@ -13,8 +13,33 @@ data:extend(
 		--starting_status = "locked",
 		trigger =
 		{
-			type = "build-entity",
-			entity = "vrauks-paddock-mk01"
+			type = "or",
+			triggers = {
+				{
+					type = "build-entity",
+					entity = "fwf-mk01"
+				},
+				{
+					type = "build-entity",
+					entity = "seaweed-crop-mk01"
+				},
+				{
+					type = "build-entity",
+					entity = "sap-extractor-mk01"
+				},
+				{
+					type = "build-entity",
+					entity = "moss-farm-mk01"
+				},
+				{
+					type = "build-entity",
+					entity = "moondrop-greenhouse-mk01"
+				},
+				{
+					type = "build-entity",
+					entity = "vrauks-paddock-mk01"
+				},
+			},
 		},
 		--dependencies = {'introduction'},
 		is_title = true,


### PR DESCRIPTION
It used to only trigger when building the vrauk paddock, but now it triggers if you place any building that requires modules to function.

I'll probably improve the tips and tricks further down the line somewhere.

resolves pyanodon/pybugreports#65