### PR TITLE
Circuit connections for Collectors Mks. I-IV

### DIFF
--- a/prototypes/buildings/collector-mk02.lua
+++ b/prototypes/buildings/collector-mk02.lua
@@ -63,6 +63,12 @@ ENTITY {
         width = 4,
         height = 4
     },
+
+    require ("__pyalienlife__/prototypes/circuit-connector-definitions-pyal"),
+    circuit_wire_connection_points = collector_connector_definitions.points,
+    circuit_connector_sprites = collector_connector_definitions.sprites,
+    circuit_wire_max_distance = default_circuit_wire_max_distance,
+
     animations = {
         layers = {
             {

--- a/prototypes/buildings/collector-mk03.lua
+++ b/prototypes/buildings/collector-mk03.lua
@@ -62,6 +62,12 @@ ENTITY {
         width = 4,
         height = 4
     },
+
+    require ("__pyalienlife__/prototypes/circuit-connector-definitions-pyal"),
+    circuit_wire_connection_points = collector_connector_definitions.points,
+    circuit_connector_sprites = collector_connector_definitions.sprites,
+    circuit_wire_max_distance = default_circuit_wire_max_distance,
+
     animations = {
         layers = {
             {

--- a/prototypes/buildings/collector-mk04.lua
+++ b/prototypes/buildings/collector-mk04.lua
@@ -61,6 +61,12 @@ ENTITY {
         width = 4,
         height = 4
     },
+ 
+    require ("__pyalienlife__/prototypes/circuit-connector-definitions-pyal"),
+    circuit_wire_connection_points = collector_connector_definitions.points,
+    circuit_connector_sprites = collector_connector_definitions.sprites,
+    circuit_wire_max_distance = default_circuit_wire_max_distance,
+
     animations = {
         layers = {
             {

--- a/prototypes/buildings/collector.lua
+++ b/prototypes/buildings/collector.lua
@@ -61,6 +61,12 @@ ENTITY {
         width = 4,
         height = 4
     },
+
+    require ("__pyalienlife__/prototypes/circuit-connector-definitions-pyal"),
+    circuit_wire_connection_points = collector_connector_definitions.points,
+    circuit_connector_sprites = collector_connector_definitions.sprites,
+    circuit_wire_max_distance = default_circuit_wire_max_distance,
+
     animations = {
         layers = {
             {

--- a/prototypes/circuit-connector-definitions-pyal.lua
+++ b/prototypes/circuit-connector-definitions-pyal.lua
@@ -1,0 +1,13 @@
+-- Holds circuit connection definitions for PyAL entities.
+-- variation counts from 0 (Python-like).
+
+collector_connector_definitions = circuit_connector_definitions.create
+(
+  universal_connector_template,
+  {--Directions are up, right, down, left.
+    { variation = 24, main_offset = util.by_pixel(-110, -122), shadow_offset = util.by_pixel(-100, -117), show_shadow = false }, 
+    { variation = 27, main_offset = util.by_pixel(105, 95), shadow_offset = util.by_pixel(107, 100), show_shadow = false },
+    { variation = 26, main_offset = util.by_pixel(-105, 100), shadow_offset = util.by_pixel(-104, 107), show_shadow = false },
+    { variation = 26, main_offset = util.by_pixel(-105, 100), shadow_offset = util.by_pixel(-111, 112), show_shadow = false }
+  }
+)


### PR DESCRIPTION
This PR adds circuit connectivity for all four marks of Collectors, so that they can output available resources in the same way that vanilla mining drills can. The image below shows the current implementation for Mks. I-IV, with their outputs facing up, right, down and left respectively.

![20221119190201_1](https://user-images.githubusercontent.com/47102583/202910466-d2158d6e-55cd-4a3c-bb82-1515d6eb3566.jpg)

The relevant definitions are pulled from a new circuit connector definitions file, which can be expanded in future to handle new entities.

Partly addresses [the relevant GitHub issue](https://github.com/pyanodon/pycoalprocessing/issues/237) on the Py Coal Processing repo, but only for Collectors.