### PR TITLE
fix nil crash when loading old save

### DIFF
--- a/migrations/biofluid.lua
+++ b/migrations/biofluid.lua
@@ -6,6 +6,7 @@ require 'scripts.biofluid.biofluid-gui'
 local broken_graphics = {}
 local invalid_coords = {}
 
+global.biofluid_undergrounds = global.biofluid_undergrounds or {}
 global.network_positions = global.network_positions or {}
 
 for _, surface in pairs(game.surfaces) do

--- a/migrations/biofluid.lua
+++ b/migrations/biofluid.lua
@@ -6,6 +6,8 @@ require 'scripts.biofluid.biofluid-gui'
 local broken_graphics = {}
 local invalid_coords = {}
 
+global.network_positions = global.network_positions or {}
+
 for _, surface in pairs(game.surfaces) do
     local network_positions = global.network_positions[surface.index]
     if network_positions then

--- a/scripts/turd/turd-migration.lua
+++ b/scripts/turd/turd-migration.lua
@@ -3,6 +3,7 @@ return function(master_tech_name, sub_tech_name)
     local reset_time_in_ticks = reset_time_in_hours * 3600 * 60
 
     global.turd_migrations = global.turd_migrations or {}
+    global.turd_bonuses = global.turd_bonuses or {}
 
     for _, force in pairs(game.forces) do
         global.turd_migrations[force.index] = global.turd_migrations[force.index] or {}


### PR DESCRIPTION
crash 1: turd-migration.lua
- attempt to index field "turd_bonuses" 

this happens on old saves created before turd_bonuses 

crash 2: biofluid.lua
- attempt to index field 'network_positions'
- biofluid_underground nil pair

this happens on old saves created before biofluid