### PR TITLE
Fix ru Fluid mining drilll locale

### DIFF
--- a/locale/ru/entity.cfg
+++ b/locale/ru/entity.cfg
@@ -253,10 +253,10 @@ zungror-lair-mk01=Логово зунгроров МК1
 zungror-lair-mk02=Логово зунгроров МК2
 zungror-lair-mk03=Логово зунгроров МК3
 zungror-lair-mk04=Логово зунгроров МК4
-fluid-drill-mk01=Буровая установка для добычи жидкости МК1
-fluid-drill-mk02=Буровая установка для добычи жидкости МК2
-fluid-drill-mk03=Буровая установка для добычи жидкости МК3
-fluid-drill-mk04=Буровая установка для добычи жидкости МК4
+fluid-drill-mk01=Жидкостный бур МК1
+fluid-drill-mk02=Жидкостный бур МК2
+fluid-drill-mk03=Жидкостный бур МК3
+fluid-drill-mk04=Жидкостный бур МК4
 hidden-beacon=Скрытый маяк
 hidden-beacon-turd=Маяк Т.У.Р.Д.
 


### PR DESCRIPTION
Corrected the Russian translation of "Fluid Mining Drill" from "Буровая установка для добычи жидкости" (literally translated as "Drilling setup for fluid extraction") to "Жидкостный бур" ("Fluid Drill"). The original translation incorrectly implied fluid extraction, while the corrected version accurately reflects the drill's use of fluids in the mining process.