### PR TITLE
Fixed yaedols turd path 2 didnt return barrels on 3rd recipe

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -18,6 +18,7 @@ Date: ???
     - Allowed zipir assisted embryology to use productivity
     - Fixed that zipir cubs had no uses (https://github.com/pyanodon/pybugreports/issues/432)
     - Fixed misspelling of genes as "gens" (https://github.com/pyanodon/pybugreports/issues/431)
+    - Fixed yaedols turd path 2 did not return barrels
 ---------------------------------------------------------------------------------------------------
 Version: 2.1.21
 Date: 2024-2-2

--- a/prototypes/upgrades/yaedols.lua
+++ b/prototypes/upgrades/yaedols.lua
@@ -29,7 +29,8 @@ if data and not yafc_turd_integration then
         local nitrogen_barrels = math.ceil(FUN.remove_ingredient(recipe, 'nitrogen') / 50)
         if nitrogen_barrels > 0 then
             FUN.add_ingredient(recipe, {name = 'nitrogen-barrel', amount = nitrogen_barrels, type = 'item'})
-            FUN.add_result_amount(recipe, 'empty-barrel', nitrogen_barrels)
+            nitrogen_barrels = nitrogen_barrels + FUN.remove_result(recipe, 'empty-barrel')
+            FUN.add_result(recipe, {'empty-barrel', nitrogen_barrels})
         end
 
         data:extend{recipe}


### PR DESCRIPTION
![image](https://github.com/pyanodon/pyalienlife/assets/14167635/29829e2f-b230-48be-944f-6c8ec9411a9c)

adds the 3 barrels back in while maintaining the proper barrel count of rest of the recipes 