### PR TITLE
Fixing technologies for pyblock

### DIFF
--- a/prototypes/technologies/chitin.lua
+++ b/prototypes/technologies/chitin.lua
@@ -4,7 +4,7 @@ TECHNOLOGY {
     icon = "__pyalienlifegraphics__/graphics/technology/chitin.png",
     icon_size = 128,
     order = "c-a",
-    prerequisites = {"genetic-design"},
+    prerequisites = {},
     effects = {},
     unit = {
         count = 200,

--- a/prototypes/technologies/dingrits.lua
+++ b/prototypes/technologies/dingrits.lua
@@ -4,7 +4,7 @@ TECHNOLOGY {
     icon = "__pyalienlifegraphics__/graphics/technology/dingrits.png",
     icon_size = 128,
     order = "c-a",
-    prerequisites = {"land-animals-mk03","biotech-mk03","genetic-design"},
+    prerequisites = {"land-animals-mk03","biotech-mk03"},
     effects = {},
     unit = {
         count = 200,

--- a/prototypes/technologies/scrondrix.lua
+++ b/prototypes/technologies/scrondrix.lua
@@ -4,7 +4,7 @@ TECHNOLOGY {
     icon = "__pyalienlifegraphics__/graphics/technology/scrondrix.png",
     icon_size = 128,
     order = "c-a",
-    prerequisites = {"land-animals-mk03","genetics-mk04","genetic-design"},
+    prerequisites = {"land-animals-mk03","genetics-mk04"},
     effects = {},
     unit = {
         count = 150,

--- a/prototypes/technologies/vatbrain.lua
+++ b/prototypes/technologies/vatbrain.lua
@@ -24,7 +24,7 @@ TECHNOLOGY {
     icon = "__pyalienlifegraphics2__/graphics/technology/vatbrain-mk02.png",
     icon_size = 128,
     order = "c-a",
-    prerequisites = {"vatbrain-nk01"},
+    prerequisites = {"vatbrain-mk01"},
     dependencies = {"vatbrain-mk01"},
     effects = {},
     unit = {


### PR DESCRIPTION
Due to strange load orders, pYal will refuse to load if pyblock is enabled, citing technologies that are normally removed by pYpp. Fixing these technology names will cause the game to load.