### PR TITLE
Fix caravan deleting items

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -7,6 +7,7 @@ Date: 2024-10-27
     - Updated Russian translation.
     - Fixed a crashy migration related to bhoddos turd path 1.
     - Removed ash
+    - Fixed caravans deleting items when filling outpost
 ---------------------------------------------------------------------------------------------------
 Version: 3.0.9
 Date: 2024-10-24

--- a/scripts/caravan/caravan-prototypes.lua
+++ b/scripts/caravan/caravan-prototypes.lua
@@ -141,9 +141,9 @@ local function transfer_all_items(input_inventory, output_inventory)
 	if input_inventory.is_empty() or output_inventory.is_full() then return end
 	for _, stack in pairs(input_inventory.get_contents()) do
 		if output_inventory.can_insert(stack) then
-			stack.inserted_count = output_inventory.insert(stack)
-			if stack.inserted_count ~= 0 then
-				input_inventory.remove(stack)
+			local inserted_count = output_inventory.insert(stack)
+			if inserted_count ~= 0 then
+				input_inventory.remove({name = stack.name, count = inserted_count})
 			end
 		end
 	end


### PR DESCRIPTION
Fixes https://github.com/pyanodon/pybugreports/issues/650

I turned `inserted_count` into a local, I don't see any reason it should on the table. If it does need to be there, my bad, I can change it.