### PR TITLE
Fix for biofluid network deleting fluid

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -3,6 +3,8 @@ Version: 2.1.43
 Date: in 5 hours
   Changes:
     - fixed some recipes outputting more steam than input water when using productivity modules
+	- Fix for biofluid network deleting fluid due to a bug in cached path finding
+	- Added logs to warn the player in case path finding fails again instead of failing silently
 ---------------------------------------------------------------------------------------------------
 Version: 2.1.42
 Date: 2024-9-4

--- a/scripts/biofluid/biofluid.lua
+++ b/scripts/biofluid/biofluid.lua
@@ -290,6 +290,7 @@ local function set_target(biorobot_data, target)
 			low_priority = true,
 			allow_paths_through_own_entities = true,
 			allow_destroy_friendly_entities = true,
+			cache = false,
 		},
 		distraction = defines.distraction.none
 	}
@@ -553,7 +554,22 @@ end
 Biofluid.events.on_ai_command_completed = function(event)
 	local biorobot_data = global.biofluid_robots[event.unit_number]
 	if not biorobot_data then return end
-	if event.result ~= defines.behavior_result.success then go_home(biorobot_data); return end
+
+	if event.result ~= defines.behavior_result.success then
+		if biorobot_data.delivery_amount > 0 then
+			local names =
+			{
+				[defines.behavior_result.in_progress] = 'in_progress',
+				[defines.behavior_result.fail] = 'fail',
+				[defines.behavior_result.deleted] = 'deleted',
+			}
+
+			game.print('fluid lost, amount: ' .. biorobot_data.delivery_amount .. ' ' .. names[event.result])
+			game.print(global.biofluid_requesters[biorobot_data.requester].entity.position)
+		end
+		go_home(biorobot_data);
+		return
+	end
 
 	if biorobot_data.status == PICKING_UP then
 		pickup(biorobot_data)


### PR DESCRIPTION
There seems to be a bug in 1.1.110 with cached path finding. It fails every now and then (on my save it was around 1 failure every ~5 minutes with 100 gobachevs in a relatively small network) with the current biofluid network settings even though the entities should not be able to collide with anything. Consequently the fluid that the drone was carrying is lost. This is a massive issue for costly fluids (in my case it was molten salt which can only be replenished very slowly).

Turning cached path finding off solves the issue, although so does increasing the radius in the go_to_location call to 3 and increasing the ai_settings (path finding coarseness) on gobachev to 0. All of these solutions solve the problem on their own (tested by waiting around for 10 minutes and didn't get any new logs regarding the bug). The reason I decided on simply turning the whole cached path finding off is because it seemed like the cleanest solution and the least likely to make the bug reappear later.

Eventually I plan on reporting this issue on the base game bug report forum. The only reason I am putting that off is because their guidelines state that one should only do so on the newest release, but that is not compatible with the modpack and I fear it would be hard for me to find another way to reproduce it. (Even though I highly doubt that it has been fixed because a quick google search  and a fast sweep on the forum does not show any similar issues and path finding is not essential for the base game's main gameplay loop.....I doubt that it has even been noticed.)