### PR TITLE
Fix for Biofluid trips with 0 fluid

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -3,6 +3,7 @@ Version: 3.0.24
 Date: ?
   Changes:
     - Fixed digosaurs pywiki page missing [item=dried-meat] → 1 ore info. Resolves https://github.com/pyanodon/pybugreports/issues/725
+    - Fixed Biofluid trips with 0 fluid when provider had less to give or requester asked for less than a certain amount
 ---------------------------------------------------------------------------------------------------
 Version: 3.0.23
 Date: 2024-11-17

--- a/scripts/biofluid/biofluid.lua
+++ b/scripts/biofluid/biofluid.lua
@@ -267,9 +267,7 @@ local function process_unfulfilled_requests(unfulfilled_request, relavant_fluids
 				error("Invalid operator: " .. operator)
 			end
 		end
-		local can_give = contents.amount - (allocated_fluids_from_providers[p.unit_number] or 0)
 		provider = p
-		unfulfilled_request.amount = min(amount, can_give)
 		break
 		::continue::
 	end


### PR DESCRIPTION
The 2 removed lines preemptively reduced the requested amount before sending the request out in start_journey, which also gets reduced afterwards indirectly by modifying requester_data.incoming. This caused Biofluid trips with a smaller amount of fluid than the minimum requirement, which would often be 0. The 2 lines were probably left there by accident after introducing requester_data.incoming because they seemed to serve the same purpose.

As a sidenote I only tested this on Frozen in 1.1.110 because last time I checked the newest release was still not working with 2.0 but I did check the code and it seems like this part has not changed since then and it fixed the problem in the old version.