### PR TITLE
Don't require electric mining drill before red

### DIFF
--- a/prototypes/buildings/flora-collector.lua
+++ b/prototypes/buildings/flora-collector.lua
@@ -4,7 +4,7 @@ RECIPE {
     energy_required = 5,
     enabled = true,
     ingredients = {
-        {type = "item", name = "electric-mining-drill", amount = 2},
+        {type = "item", name = "burner-mining-drill",   amount = 2},
         {type = "item", name = "soil-extractor-mk01",   amount = 1},
         {type = "item", name = "electronic-circuit",    amount = 5},
         {type = "item", name = "iron-gear-wheel",       amount = 10},

--- a/prototypes/updates/pyhightech-updates.lua
+++ b/prototypes/updates/pyhightech-updates.lua
@@ -156,7 +156,7 @@ RECIPE("seaweed-crop-mk01"):replace_ingredient("electronic-circuit", "inductor1"
 RECIPE("sap-extractor-mk01"):replace_ingredient("electronic-circuit", "inductor1"):replace_ingredient("inserter", "burner-inserter")
 RECIPE("repair-pack"):replace_ingredient("electronic-circuit", "inductor1")
 RECIPE("electric-mining-drill"):add_unlock("electric-mining-drill").enabled = false
-RECIPE("flora-collector-mk01"):replace_ingredient("electronic-circuit", "inductor1"):replace_ingredient("electric-mining-drill", "burner-mining-drill")
+RECIPE("flora-collector-mk01"):replace_ingredient("electronic-circuit", "inductor1")
 RECIPE("eaf-mk01"):replace_ingredient("electric-mining-drill", "fluid-drill-mk01")
 RECIPE("impact-crusher-mk01"):replace_ingredient("electric-mining-drill", "fluid-drill-mk01")
 RECIPE("hydroclassifier-mk01"):replace_ingredient("electric-mining-drill", "fluid-drill-mk01")


### PR DESCRIPTION
- As of 2.0.7 Electric Mining Drill is behind research but is a requirement of Flora Collector MK01 which is required to research
- Replace the Electric Mining Drill with a Burner Mining Drill this matches what was done for PyHighTech just unconditionally

Resolves https://github.com/pyanodon/pybugreports/issues/755