### PR TITLE
Fix crash when pyHT not loaded

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -3,6 +3,7 @@ Version: 3.0.32
 Date: ?
   Changes:
     - Composter TURD path 2 no longer generates methanol. Now it instead generates coalbed gas. Resolves https://github.com/pyanodon/pybugreports/issues/757
+    - Biomass destruction only generates methane if pyHT installed. Resolves https://github.com/pyanodon/pybugreports/issues/794
     - Greatly increased the science pack requirement for the wood processing unit turd from 500 -> 7000. Resolves https://github.com/pyanodon/pybugreports/issues/758
     - Fix the base productivity on Composter from Composter TURD path 2.
     - All caravans can use all caravan outpost types

--- a/prototypes/upgrades/compost.lua
+++ b/prototypes/upgrades/compost.lua
@@ -120,7 +120,6 @@ if data and not yafc_turd_integration then
         results = {
             {type = "fluid", name = "coalbed-gas",       amount = 60},
             {type = "fluid", name = "carbon-dioxide", amount = 40},
-            {type = "fluid", name = "methane",        amount = 40},
             {type = "fluid", name = "coal-gas",       amount = 20},
         },
         icon = "__pyalienlifegraphics__/graphics/icons/biomass-destruction.png",
@@ -128,6 +127,10 @@ if data and not yafc_turd_integration then
         subgroup = "py-alienlife-items",
         allow_productivity = true,
     }}
+
+    if mods["pyhightech"] then
+        RECIPE("biomass-destruction"):add_result { type = "fluid", name = "methane", amount = 40}
+    end
 
     data:extend {{
         type = "recipe",


### PR DESCRIPTION
Fixes https://github.com/pyanodon/pybugreports/issues/794

I made it so that methane is only added to the recipe if pyHT is loaded. I'm not sure if this is the best way to fix it balance-wise, but it should fix the crash