### PR TITLE
Moved vessel-to-ground from Biofluid Stage 2 to Biofluid Stage 1

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -21,6 +21,7 @@ Date: 2024-11-29
     - Added FSM animations to the incubator. Resolves https://github.com/pyanodon/pybugreports/issues/753
     - Improved the pipe connection graphics for the incubator.
     - Muted the working sounds for the incubator.
+    - Moved Underground Vessel for the biofluid network from Biofluid Stage 2 to Biofluid Stage 1
 ---------------------------------------------------------------------------------------------------
 Version: 3.0.30
 Date: 2024-11-29

--- a/prototypes/biofluid/vessel.lua
+++ b/prototypes/biofluid/vessel.lua
@@ -25,7 +25,7 @@ RECIPE {
     ingredients = {
         {"vessel",               10},
         {"earth-generic-sample", 1},
-        {"peptidase-m58",        1},
+        {"microcin-j25",         1},
         {"alien-sample-02",      2},
         {"bio-sample",           3},
         {type = "fluid",         name = "water-saline", amount = 40},
@@ -35,7 +35,7 @@ RECIPE {
     results = {
         {"vessel-to-ground", 10}
     }
-}:add_unlock("biofluid-mk02")
+}:add_unlock("biofluid-mk01")
 
 ITEM {
     type = "item",


### PR DESCRIPTION
All pipes block movement.  For playability, all pipes come paired with underground versions immediately on research.  The exception was vessels in the biofluid network, where underground vessels were placed on the next tech tier, Biofluid Stage 2.   While the biofluid network offers some interesting options at Biofluid Stage 1 these options come at the cost of erecting impassible terrain throughout the base, which is impractical given that flight is not an option at that tech level.

The conclusion was to move Underground Vessels from Stage 2 to Stage 1, bringing their access in-line with the other pipe types.  The additional utility of the biofluid network is offset by its increased cost to build and maintain.

One issue is that vessel-to-ground required peptidase-m58, which is not available at Biofluid 1.  This requirement was changed to microcin-j25, just like individual vessel units.