### PR TITLE
Fix base speeds of higher tier seaweed buildings

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -2,6 +2,7 @@
 Version: 3.0.35
 Date: ?
   Changes:
+    - Higher tier seaweed buildings now have the correct base speed again.  Resolves https://github.com/pyanodon/pybugreports/issues/842
     - Decreased volume for the reproductive complex.
     - Edited working sound aggregation for the reproductive complex such that only 1 smooth jazz plays concurrently.
     - Updated the locale of the moss turd. Resolves https://github.com/pyanodon/pybugreports/issues/826

--- a/prototypes/buildings/seaweed-crop.lua
+++ b/prototypes/buildings/seaweed-crop.lua
@@ -106,7 +106,7 @@ for i = 1, 4 do
         module_slots = MODULE_SLOTS,
         allowed_effects = {"speed", "productivity", "consumption", "pollution", "quality"},
         crafting_categories = {"seaweed"},
-        crafting_speed = py.farm_speed(MODULE_SLOTS, FULL_CRAFTING_SPEED),
+        crafting_speed = (i == 1) and py.farm_speed(MODULE_SLOTS, FULL_CRAFTING_SPEED) or py.farm_speed_derived(MODULE_SLOTS, "seaweed-crop-mk01"),
         energy_source = {
             type = "electric",
             usage_priority = "secondary-input",


### PR DESCRIPTION
Fix for https://github.com/pyanodon/pybugreports/issues/842
Now appropriately sets speeds to 1/4/9/16 when tier is full of modules.