### PR TITLE
Add fluid caravans

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -23,6 +23,7 @@ Date: ???
     - Fixed many caravan interrupts quirks. They now behave like train interrupts.
     - Added and/or buttons to caravan's interrupt conditions
     - Clicking on a caravan while trying to place a building will no longer open the caravan GUI (just like vanilla GUIs).
+    - Add fluid caravans, creatures capable of transporting fluids between two fluid outposts.
 ---------------------------------------------------------------------------------------------------
 Version: 3.0.47
 Date: 2025-7-20

--- a/data.lua
+++ b/data.lua
@@ -394,8 +394,13 @@ require "prototypes/creatures/caravan"
 require "prototypes/creatures/flying-caravan"
 require "prototypes/creatures/nuka-caravan"
 data.raw.unit["caravan"].affected_by_tiles = false
+if settings.startup["py-enable-fluid-caravans"].value then
+    require "prototypes/creatures/fluid-caravan"
+    data.raw.unit["fluidavan"].affected_by_tiles = false
+end
 data.raw.unit["flyavan"].affected_by_tiles = false
 data.raw.unit["nukavan"].affected_by_tiles = false
+require "prototypes/buildings/fluid-outpost"
 require "prototypes/buildings/outpost"
 require "prototypes/buildings/outpost-aerial"
 require "prototypes/creatures/digosaurus"

--- a/locale/en/caravan.cfg
+++ b/locale/en/caravan.cfg
@@ -1,15 +1,19 @@
 [entity-name] 
 caravan=Caravan
+fluidavan=Fluid caravan
 flyavan=Aerial caravan
 nukavan=☢ Caravan ☢
 outpost=Caravan outpost
+fluid-outpost=Caravan fluid outpost
 outpost-aerial=Aerial outpost
 
 [entity-description] 
 caravan=Slow moving land creature with a lack of free will. Not too bright, but reliable.
+fluidavan=Slow moving land creature with a lack of free will, and a fluid tank on its back.
 flyavan=Sometimes we push way too far. Heavily modified creature made with earth whale genes and trits alien genome, plus with some organs and parts changed for a similar biomechanical part to allow floating and cargo capabilities.
 nukavan=A type of caravan with a "special delivery".
 outpost=Item and food storage for land-based caravans.
+fluid-outpost=Fluid storage for land-based fluid caravans.
 outpost-aerial=Item and food storage for aerial caravans.
 
 [entity-status]
@@ -42,16 +46,20 @@ delete-interrupt=Delete interrupt
 confirm-deletion=Are you sure?
 cancel-deletion=Cancel deletion
 caravan-inventory=Caravan inventory
+caravan-fluid-contents=Fluid caravan contents:
 not-specified=(Not specified)
 interrupt-header-tooltip=Interrupts are conditions that can be added to schedules. Their configuration is shared globally between all caravans.
 destination-unavailable=Destination is unavailable. Click here to reassign it.
+flush-contents=Flush __1__ from this caravan.
 
 [caravan-actions]
 time-passed=Wait
 store-food=Store food
 store-specific-food=Store food until
 fill-inventory=Fill cargo
+fill-tank=Fill fluid tank
 empty-inventory=Empty cargo
+empty-tank=Empty fluid tank
 item-count=Until caravan has exactly N items
 inverse-item-count=Until target has exactly N items
 detonate=Detonate
@@ -65,8 +73,12 @@ load-target=Load items until target has
 unload-target=Unload items until target has
 is-inventory-full=Inventory full
 is-inventory-empty=Inventory empty
+is-tank-full=Fluid tank full
+is-tank-empty=Fluid tank empty
 caravan-item-count=Cargo item count
 target-item-count=Target item count
+caravan-fluid-count=Tank fluid count
+target-fluid-count=Target fluid count
 food-count=Food count
 at-outpost=At specified outpost
 not-at-outpost=Not at specified outpost
@@ -94,3 +106,6 @@ caravan-map-tag=Caravan map tag
 no-fuel=Out of fuel
 no-food=Out of food
 destination-destroyed=Destination destroyed
+
+[mod-setting-name]
+py-enable-fluid-caravans=Enable fluid caravans

--- a/locale/en/caravan.cfg
+++ b/locale/en/caravan.cfg
@@ -51,6 +51,7 @@ not-specified=(Not specified)
 interrupt-header-tooltip=Interrupts are conditions that can be added to schedules. Their configuration is shared globally between all caravans.
 destination-unavailable=Destination is unavailable. Click here to reassign it.
 flush-contents=Flush __1__ from this caravan.
+tank-is-empty=Fluid tank is empty
 
 [caravan-actions]
 time-passed=Wait

--- a/prototypes/buildings/fluid-outpost.lua
+++ b/prototypes/buildings/fluid-outpost.lua
@@ -1,0 +1,146 @@
+local util = require "util"
+
+RECIPE {
+    type = "recipe",
+    name = "fluid-outpost",
+    energy_required = 1,
+    category = "crafting",
+    enabled = false,
+    ingredients = {
+        {type = "item", name = "steel-plate",    amount = 5},
+        {type = "item", name = "small-parts-01", amount = 50},
+        {type = "item", name = "concrete",       amount = 20},
+        {type = "item", name = "glass",          amount = 5},
+        {type = "item", name = "py-tank-4000",   amount = 1}
+    },
+    results = {{type = "item", name = "fluid-outpost", amount = 1}}
+}:add_unlock("zoology")
+
+ITEM {
+    type = "item",
+    name = "fluid-outpost",
+    icon = "__pyalienlifegraphics2__/graphics/icons/fluid-outpost.png",
+    icon_size = 64,
+    subgroup = "py-alienlife-buildings-others",
+    order = "b-a",
+    place_result = "fluid-outpost",
+    stack_size = 10
+}
+
+data:extend {{
+    inventory_type = "with_filters_and_bar",
+    scale_info_icons = true,
+    name = "fluid-outpost",
+    type = "storage-tank",
+    circuit_connector = table.deepcopy(data.raw["storage-tank"]["storage-tank"].circuit_connector), -- todo
+    circuit_wire_max_distance = 9,
+    close_sound = {
+        filename = "__base__/sound/metallic-chest-close.ogg",
+        volume = 0.42999999999999998
+    },
+    collision_box = {
+        {
+            -2.9,
+            -2.9
+        },
+        {
+            2.9,
+            2.9
+        }
+    },
+    corpse = "big-remnants",
+    damaged_trigger_effect = {
+        damage_type_filters = "fire",
+        entity_name = "spark-explosion",
+        offset_deviation = {
+            {
+                -0.5,
+                -0.5
+            },
+            {
+                0.5,
+                0.5
+            }
+        },
+        offsets = {
+            {
+                0,
+                1
+            }
+        },
+        type = "create-entity"
+    },
+    dying_explosion = "steel-chest-explosion",
+    flags = {
+        "placeable-neutral",
+        "player-creation"
+    },
+    icon = "__pyalienlifegraphics2__/graphics/icons/fluid-outpost.png",
+    icon_size = 64,
+    fluid_box = {
+        -- don't hardcode so that volume gets adjusted when "realistic" setting is on.
+        volume = data.raw["storage-tank"]["py-tank-4000"].fluid_box.volume,
+        pipe_covers = _G.pipecoverspictures(),
+        pipe_connections = {
+            {
+                position = {0.5, 2.5},
+                direction = defines.direction.south
+            },
+        }
+    },
+    window_bounding_box = {{-0.0, 0.0}, {0.0, 0.0}},
+    max_health = 600,
+    minable = {
+        mining_time = 0.2,
+        result = "fluid-outpost"
+    },
+    open_sound = {
+        filename = "__base__/sound/metallic-chest-open.ogg",
+        volume = 0.42999999999999998
+    },
+    pictures = {
+        picture = {
+         layers = {{
+                filename = "__pyalienlifegraphics2__/graphics/entity/outpost/off.png",
+                height = 224,
+                width = 224,
+                priority = "extra-high",
+                shift = util.by_pixel(16, -16),
+            }},
+        },
+        fluid_background = py.empty_image(),
+        window_background = py.empty_image(),
+        flow_sprite = py.empty_image(),
+        gas_flow = py.empty_image()
+    },
+    flow_length_in_ticks = 360,
+    impact_category = "metal-large",
+    working_sound = {
+        sound = {
+            filename = "__base__/sound/storage-tank.ogg",
+            volume = 0.8
+        },
+        apparent_volume = 1.5,
+        max_sounds_per_prototype = 3
+    },
+    resistances = {
+        {
+            percent = 90,
+            type = "fire"
+        },
+        {
+            percent = 60,
+            type = "impact"
+        }
+    },
+    selection_box = {
+        {
+            -3.0,
+            -3.0
+        },
+        {
+            3.0,
+            3.0
+        }
+    }
+}}

--- a/prototypes/creatures/fluid-caravan.lua
+++ b/prototypes/creatures/fluid-caravan.lua
@@ -1,0 +1,212 @@
+local util = require "util"
+
+RECIPE {
+    type = "recipe",
+    name = "fluidavan",
+    energy_required = 50,
+    category = "creature-chamber",
+    enabled = false,
+    ingredients = {
+        {type = "item",  name = "cocoon",               amount = 10},
+        {type = "item",  name = "bio-sample",           amount = 10},
+        {type = "item",  name = "moss-gen",             amount = 15},
+        {type = "item",  name = "earth-generic-sample", amount = 1},
+        {type = "fluid", name = "water-saline",         amount = 100},
+        {type = "item",  name = "py-tank-4000",         amount = 1},
+        {type = "item",  name = "pump",                 amount = 2}
+    },
+    results = {{type = "item", name = "fluidavan", amount = 1}}
+}:add_unlock("zoology")
+
+ITEM {
+    type = "item-with-tags",
+    name = "fluidavan",
+    additional_pastable_entities = {"fluidavan", "fluidavan-turd"},
+    icon = "__pyalienlifegraphics2__/graphics/icons/fluid-caravan.png",
+    icon_size = 64,
+    subgroup = "py-alienlife-special-creatures",
+    order = "a",
+    place_result = "fluidavan",
+    stack_size = 1,
+    flags = {"not-stackable"}
+}
+
+data:extend {{
+    type = "unit",
+    ai_settings = {do_separation = false},
+    additional_pastable_entities = {"fluidavan", "fluidavan-turd"},
+    name = "fluidavan",
+    can_open_gates = true,
+    map_color = {1, 1, 1},
+    radar_range = 1,
+    icon = "__pyalienlifegraphics2__/graphics/icons/fluid-caravan.png",
+    icon_size = 64,
+    alert_icon_scale = 1,
+    flags = {"placeable-player", "placeable-off-grid", "not-repairable", "breaths-air", "building-direction-8-way"},
+    minable = {mining_time = 0.1, result = "fluidavan"},
+    max_health = 3125,
+    order = "b-b-a",
+    collision_mask = {layers = {caravan_collision_mask = true}, not_colliding_with_itself = true},
+    subgroup = "enemies",
+    healing_per_tick = 0.03,
+    collision_box = {{-0.45, -0.45}, {0.45, 0.45}},
+    selection_priority = 51,
+    selection_box = {{-1.5, -1.5}, {1.5, 1.5}},
+    attack_parameters = {
+        type = "projectile",
+        range = 0,
+        cooldown = 0,
+        ammo_category = "melee",
+        ammo_type = _G.make_unit_melee_ammo_type(0),
+        --sound = make_biter_roars(0.4),
+        animation = {
+            layers = {
+                {
+                    filenames = {
+                        "__pyalienlifegraphics2__/graphics/entity/caravan/caravan-walk-01.png",
+                        "__pyalienlifegraphics2__/graphics/entity/caravan/caravan-walk-02.png",
+                        "__pyalienlifegraphics2__/graphics/entity/caravan/caravan-walk-03.png",
+                        "__pyalienlifegraphics2__/graphics/entity/caravan/caravan-walk-04.png",
+                        "__pyalienlifegraphics2__/graphics/entity/caravan/caravan-walk-05.png",
+                        "__pyalienlifegraphics2__/graphics/entity/caravan/caravan-walk-06.png",
+                        "__pyalienlifegraphics2__/graphics/entity/caravan/caravan-walk-07.png",
+                        "__pyalienlifegraphics2__/graphics/entity/caravan/caravan-walk-08.png"
+                    },
+                    slice = 8,
+                    lines_per_file = 8,
+                    line_length = 8,
+                    width = 256,
+                    height = 224,
+                    frame_count = 30,
+                    direction_count = 16,
+                    shift = util.mul_shift(util.by_pixel(-0, -0), 0.5),
+                    flags = {"no-scale"},
+                },
+                {
+                    filenames = {
+                        "__pyalienlifegraphics2__/graphics/entity/caravan/caravan-walk-01-mask.png",
+                        "__pyalienlifegraphics2__/graphics/entity/caravan/caravan-walk-02-mask.png",
+                        "__pyalienlifegraphics2__/graphics/entity/caravan/caravan-walk-03-mask.png",
+                        "__pyalienlifegraphics2__/graphics/entity/caravan/caravan-walk-04-mask.png",
+                        "__pyalienlifegraphics2__/graphics/entity/caravan/caravan-walk-05-mask.png",
+                        "__pyalienlifegraphics2__/graphics/entity/caravan/caravan-walk-06-mask.png",
+                        "__pyalienlifegraphics2__/graphics/entity/caravan/caravan-walk-07-mask.png",
+                        "__pyalienlifegraphics2__/graphics/entity/caravan/caravan-walk-08-mask.png"
+                    },
+                    slice = 8,
+                    tint = {r = 1.0, g = 1.0, b = 0.0, a = 1.0},
+                    lines_per_file = 8,
+                    line_length = 8,
+                    width = 256,
+                    height = 224,
+                    frame_count = 30,
+                    direction_count = 16,
+                    shift = util.mul_shift(util.by_pixel(-0, -0), 0.5),
+                    flags = {"no-scale"},
+                },
+                {
+                    filenames = {
+                        "__pyalienlifegraphics2__/graphics/entity/caravan/sh-caravan-walk-01.png",
+                        "__pyalienlifegraphics2__/graphics/entity/caravan/sh-caravan-walk-02.png",
+                        "__pyalienlifegraphics2__/graphics/entity/caravan/sh-caravan-walk-03.png",
+                        "__pyalienlifegraphics2__/graphics/entity/caravan/sh-caravan-walk-04.png",
+                        "__pyalienlifegraphics2__/graphics/entity/caravan/sh-caravan-walk-05.png",
+                        "__pyalienlifegraphics2__/graphics/entity/caravan/sh-caravan-walk-06.png",
+                        "__pyalienlifegraphics2__/graphics/entity/caravan/sh-caravan-walk-07.png",
+                        "__pyalienlifegraphics2__/graphics/entity/caravan/sh-caravan-walk-08.png"
+                    },
+                    slice = 8,
+                    lines_per_file = 8,
+                    line_length = 8,
+                    width = 256,
+                    height = 224,
+                    frame_count = 30,
+                    shift = util.mul_shift(util.by_pixel(0, 48)),
+                    direction_count = 16,
+                    --scale = scale,
+                    draw_as_shadow = true,
+                    flags = {"no-scale"},
+                }
+            }
+        }
+    },
+    vision_distance = 30,
+    movement_speed = 0.1 * 1.4,
+    distance_per_frame = 0.13,
+    absorptions_to_join_attack = {pollution = 4},
+    distraction_cooldown = 300,
+    min_pursue_time = 10 * 60,
+    max_pursue_distance = 50,
+    dying_explosion = "blood-explosion-small",
+    has_belt_immunity = true,
+    affected_by_tiles = true,
+    run_animation = {
+        layers = {
+            {
+                filenames = {
+                    "__pyalienlifegraphics2__/graphics/entity/caravan/caravan-walk-01.png",
+                    "__pyalienlifegraphics2__/graphics/entity/caravan/caravan-walk-02.png",
+                    "__pyalienlifegraphics2__/graphics/entity/caravan/caravan-walk-03.png",
+                    "__pyalienlifegraphics2__/graphics/entity/caravan/caravan-walk-04.png",
+                    "__pyalienlifegraphics2__/graphics/entity/caravan/caravan-walk-05.png",
+                    "__pyalienlifegraphics2__/graphics/entity/caravan/caravan-walk-06.png",
+                    "__pyalienlifegraphics2__/graphics/entity/caravan/caravan-walk-07.png",
+                    "__pyalienlifegraphics2__/graphics/entity/caravan/caravan-walk-08.png"
+                },
+                slice = 8,
+                lines_per_file = 8,
+                line_length = 8,
+                width = 256,
+                height = 224,
+                frame_count = 30,
+                direction_count = 16,
+                shift = util.mul_shift(util.by_pixel(-0, -0)),
+                flags = {"no-scale"},
+            },
+            {
+                filenames = {
+                    "__pyalienlifegraphics2__/graphics/entity/caravan/caravan-walk-01-mask.png",
+                    "__pyalienlifegraphics2__/graphics/entity/caravan/caravan-walk-02-mask.png",
+                    "__pyalienlifegraphics2__/graphics/entity/caravan/caravan-walk-03-mask.png",
+                    "__pyalienlifegraphics2__/graphics/entity/caravan/caravan-walk-04-mask.png",
+                    "__pyalienlifegraphics2__/graphics/entity/caravan/caravan-walk-05-mask.png",
+                    "__pyalienlifegraphics2__/graphics/entity/caravan/caravan-walk-06-mask.png",
+                    "__pyalienlifegraphics2__/graphics/entity/caravan/caravan-walk-07-mask.png",
+                    "__pyalienlifegraphics2__/graphics/entity/caravan/caravan-walk-08-mask.png"
+                },
+                slice = 8,
+                tint = {r = 1.0, g = 1.0, b = 0.0, a = 1.0},
+                lines_per_file = 8,
+                line_length = 8,
+                width = 256,
+                height = 224,
+                frame_count = 30,
+                direction_count = 16,
+                shift = util.mul_shift(util.by_pixel(-0, -0), 0.5),
+                flags = {"no-scale"},
+            },
+            {
+                filenames = {
+                    "__pyalienlifegraphics2__/graphics/entity/caravan/sh-caravan-walk-01.png",
+                    "__pyalienlifegraphics2__/graphics/entity/caravan/sh-caravan-walk-02.png",
+                    "__pyalienlifegraphics2__/graphics/entity/caravan/sh-caravan-walk-03.png",
+                    "__pyalienlifegraphics2__/graphics/entity/caravan/sh-caravan-walk-04.png",
+                    "__pyalienlifegraphics2__/graphics/entity/caravan/sh-caravan-walk-05.png",
+                    "__pyalienlifegraphics2__/graphics/entity/caravan/sh-caravan-walk-06.png",
+                    "__pyalienlifegraphics2__/graphics/entity/caravan/sh-caravan-walk-07.png",
+                    "__pyalienlifegraphics2__/graphics/entity/caravan/sh-caravan-walk-08.png"
+                },
+                slice = 8,
+                lines_per_file = 8,
+                line_length = 8,
+                width = 256,
+                height = 224,
+                frame_count = 30,
+                shift = util.mul_shift(util.by_pixel(-0, 48)),
+                direction_count = 16,
+                draw_as_shadow = true,
+                flags = {"no-scale"},
+            }
+        }
+    }
+}}

--- a/prototypes/upgrades/creature.lua
+++ b/prototypes/upgrades/creature.lua
@@ -9,6 +9,11 @@ local units = {
     "flyavan",
     "nukavan",
 }
+
+if settings.startup["py-enable-fluid-caravans"].value then
+    table.insert(units, "fluidavan")
+end
+
 local path_3_effects = {}
 for _, unit_name in pairs(units) do
     path_3_effects[#path_3_effects + 1] = {type = "recipe-replacement", old = unit_name, new = unit_name .. "-turd"}
@@ -104,7 +109,7 @@ if data and not yafc_turd_integration then
             results = {{type = "item", name = name, amount = 1}},
         }
 
-        if unit_name == "caravan" or unit_name == "flyavan" or unit_name == "nukavan" then
+        if unit_name == "caravan" or unit_name == "fluidavan" or unit_name == "flyavan" or unit_name == "nukavan" then
             convert_recipe.localised_description = {"recipe-description.will-delete-metadata-warning"}
         end
 

--- a/scripts/caravan/caravan-prototypes.lua
+++ b/scripts/caravan/caravan-prototypes.lua
@@ -98,13 +98,41 @@ Caravan.valid_actions = {
         },
         ["default"] = table.invert {
             "time-passed"
+        }
+    },
+    fluidavan = {
+        ["outpost"] = table.invert{
+            "time-passed",
+            "store-food",
+            "store-specific-food",
+            "circuit-condition",
+            "circuit-condition-static"
         },
+        ["fluid-outpost"] = table.invert{
+            "time-passed",
+            "fill-tank",
+            "empty-tank",
+            "circuit-condition",
+            "circuit-condition-static"
+        },
+        ["electric-pole"] = table.invert{
+            "time-passed",
+            "circuit-condition",
+            "circuit-condition-static"
+        },
+        ["default"] = table.invert{
+            "time-passed"
+        }
     },
     ["interrupt-condition"] = {
         "is-inventory-full",
         "is-inventory-empty",
         "caravan-item-count",
         "target-item-count",
+        "is-tank-full",
+        "is-tank-empty",
+        "caravan-fluid-count",
+        "target-fluid-count",
         "food-count",
         "circuit-condition",
         "circuit-condition-static",
@@ -159,6 +187,27 @@ local caravan_prototypes = {
             cache = false
         }
     },
+    fluidavan = {
+        opens_player_inventory = true,
+        -- Only way I found to open the player inventory, in order to store food in the fluidavan
+        inventory_size = 0,
+        max_volume = prototypes.entity["py-tank-4000"].fluid_capacity,
+        fuel_size = 2,
+        destructible = false,
+        outpost = "fluid-outpost",
+        favorite_foods = Caravan.foods.caravan,
+        actions = Caravan.valid_actions.fluidavan,
+        camera_zoom = 0.8,
+        placeable_by = "fluidavan",
+        map_tag = {
+            type = "virtual",
+            name = "caravan-map-tag-mk01"
+        },
+        requeue_required = true,
+        pathfinder_flags = {
+            cache = false
+        }
+    },
     flyavan = {
         inventory_size = 90,
         opens_player_inventory = true,
@@ -203,12 +252,14 @@ local caravan_prototypes = {
     }
 }
 
-caravan_prototypes["caravan-turd"] = caravan_prototypes["caravan"]
-caravan_prototypes["flyavan-turd"] = caravan_prototypes["flyavan"]
-caravan_prototypes["nukavan-turd"] = caravan_prototypes["nukavan"]
-caravan_prototypes["caravan-turd"].placeable_by = "caravan-turd"
-caravan_prototypes["flyavan-turd"].placeable_by = "flyavan-turd"
-caravan_prototypes["nukavan-turd"].placeable_by = "nukavan-turd"
+caravan_prototypes["caravan-turd"]   = caravan_prototypes["caravan"]
+caravan_prototypes["fluidavan-turd"] = caravan_prototypes["fluidavan"]
+caravan_prototypes["flyavan-turd"]   = caravan_prototypes["flyavan"]
+caravan_prototypes["nukavan-turd"]   = caravan_prototypes["nukavan"]
+caravan_prototypes["caravan-turd"].placeable_by   = "caravan-turd"
+caravan_prototypes["fluidavan-turd"].placeable_by = "fluidavan-turd"
+caravan_prototypes["flyavan-turd"].placeable_by   = "flyavan-turd"
+caravan_prototypes["nukavan-turd"].placeable_by   = "nukavan-turd"
 
 -- small migration script to ensure we are not transfering deleted items
 -- I have no access to the JSON migrations so invalid items are just deleted

--- a/scripts/caravan/caravan-prototypes.lua
+++ b/scripts/caravan/caravan-prototypes.lua
@@ -270,8 +270,6 @@ local caravan_prototypes = {
     },
     fluidavan = {
         opens_player_inventory = true,
-        -- Only way I found to open the player inventory, in order to store food in the fluidavan
-        inventory_size = 0,
         max_volume = prototypes.entity["py-tank-4000"].fluid_capacity,
         fuel_size = 2,
         destructible = false,

--- a/scripts/caravan/caravan-prototypes.lua
+++ b/scripts/caravan/caravan-prototypes.lua
@@ -26,6 +26,87 @@ Caravan.alerts = {
     },
 }
 
+Caravan.all_actions = {
+        ["outpost"] = table.invert {
+            "time-passed",
+            "store-food",
+            "store-specific-food",
+            "fill-inventory",
+            "empty-inventory",
+            "load-caravan",
+            "unload-caravan",
+            "load-target",
+            "unload-target",
+            "circuit-condition",
+            "circuit-condition-static"
+        },
+        ["fluid-outpost"] = table.invert{
+            "time-passed",
+            "fill-tank",
+            "empty-tank",
+            "circuit-condition",
+            "circuit-condition-static"
+        },
+        ["character"] = table.invert {
+            "time-passed",
+            "store-food",
+            "store-specific-food",
+            "fill-inventory",
+            "empty-inventory",
+            "load-caravan",
+            "unload-caravan",
+            "load-target",
+            "unload-target",
+            "empty-autotrash"
+        },
+        ["unit"] = table.invert {
+            "time-passed",
+            "store-food",
+            "store-specific-food",
+            "fill-inventory",
+            "empty-inventory",
+            "load-caravan",
+            "unload-caravan",
+            "load-target",
+            "unload-target",
+        },
+        ["cargo-wagon"] = table.invert {
+            "time-passed",
+            "fill-inventory",
+            "empty-inventory",
+            "load-caravan",
+            "unload-caravan",
+            "load-target",
+            "unload-target",
+        },
+        ["car"] = table.invert {
+            "time-passed",
+            "fill-inventory",
+            "empty-inventory",
+            "load-caravan",
+            "unload-caravan",
+            "load-target",
+            "unload-target",
+        },
+        ["spider-vehicle"] = table.invert {
+            "time-passed",
+            "fill-inventory",
+            "empty-inventory",
+            "load-caravan",
+            "unload-caravan",
+            "load-target",
+            "unload-target",
+        },
+        ["electric-pole"] = table.invert {
+            "time-passed",
+            "circuit-condition",
+            "circuit-condition-static"
+        },
+        ["default"] = table.invert {
+            "time-passed"
+        }
+}
+
 Caravan.valid_actions = {
     caravan = {
         ["outpost"] = table.invert {

--- a/scripts/caravan/event-handlers/action.lua
+++ b/scripts/caravan/event-handlers/action.lua
@@ -160,7 +160,7 @@ gui_events[defines.events.on_gui_elem_changed]["py_caravan_action_comparator_lef
 
     if tags.elem_type == "signal" then
         action.circuit_condition_left = event.element.elem_value
-    elseif tags.elem_type == "item" then
+    elseif tags.elem_type == "item" or tags.elem_type == "fluid" then
         action.elem_value = event.element.elem_value
     end
 end

--- a/scripts/caravan/event-handlers/interrupts.lua
+++ b/scripts/caravan/event-handlers/interrupts.lua
@@ -189,10 +189,10 @@ gui_events[defines.events.on_gui_selection_state_changed]["py_edit_interrupt_tar
     local element = event.element
 
     local schedule = storage.edited_interrupt.schedule[element.tags.schedule_id]
-    local valid_conditions = table.invert(CaravanUtils.get_valid_actions_for_entity("caravan", schedule.entity))
+    local valid_actions = table.invert(CaravanUtils.get_all_actions_for_entity(schedule.entity))
 
     -- off-by-one index is used to show "+ Add action" text
-    if element.selected_index == 0 or element.selected_index > #valid_conditions then return end
+    if element.selected_index == 0 or element.selected_index > #valid_actions then return end
 
     local type = element.get_item(element.selected_index)[2]
 

--- a/scripts/caravan/gui/action_widgets/comparator.lua
+++ b/scripts/caravan/gui/action_widgets/comparator.lua
@@ -20,20 +20,8 @@ function P.build_circuit_comparator_widgets(parent, action, tags, elem_filters)
     right_button.elem_value = action.circuit_condition_right
 end
 
-function P.build_circuit_static_comparator_widgets(parent, action, tags, elem_filters)
-    tags.elem_type = "signal"
-
-    local selected_index = action.operator or 3
-
-    parent.add {type = "empty-widget"}.style.horizontally_stretchable = true
-    local left_button = parent.add {type = "choose-elem-button", name = prefix .. "_left_button", style = "train_schedule_item_select_button", tags = tags, elem_type = tags.elem_type, elem_filters = elem_filters}
-    parent.add {type = "drop-down", name = prefix .. "_drop_down", items = {">", "<", "=", "≥", "≤", "≠"}, selected_index = selected_index, style = "train_schedule_circuit_condition_comparator_dropdown", tags = tags}
-    number_selection.build_count_selection_button(parent, action, tags)
-    left_button.elem_value = action.circuit_condition_left
-end
-
-function P.build_item_static_comparator_widgets(parent, action, tags, elem_filters, forced_comparison)
-    tags.elem_type = "item"
+function P.build_static_comparator_widgets(parent, action, tags, elem_type, elem_filters, forced_comparison)
+    tags.elem_type = elem_type
 
     parent.add {type = "empty-widget"}.style.horizontally_stretchable = true
     local left_button = parent.add {type = "choose-elem-button", name = prefix .. "_left_button", style = "train_schedule_item_select_button", tags = tags, elem_type = tags.elem_type, elem_filters = elem_filters}
@@ -47,7 +35,11 @@ function P.build_item_static_comparator_widgets(parent, action, tags, elem_filte
 
     number_selection.build_count_selection_button(parent, action, tags)
 
-    left_button.elem_value = action.elem_value
+    if elem_type == "signal" then
+        left_button.elem_value = action.circuit_condition_left
+    else
+        left_button.elem_value = action.elem_value
+    end
 end
 
 return P

--- a/scripts/caravan/gui/action_widgets/number_selection.lua
+++ b/scripts/caravan/gui/action_widgets/number_selection.lua
@@ -14,25 +14,7 @@ function L.time_format_value(v) return v .. " s" end
 function L.count_slider_maximum_value() return 50000 end
 function L.count_slider_default_value() return 0 end
 function L.count_slider_value_step() return 10 end
-function L.count_format_value(v)
-    local s = tostring(v)
-    local len = string.len(s)
-
-    local units = {"", "k", "M", "G"}
-
-    local remainder = len % 3
-    local nb_fractional_digits = remainder == 0 and 3 or remainder
-    local res = s:sub(1, nb_fractional_digits)
-
-    if len > 1 and nb_fractional_digits == 1 then
-        local i = nb_fractional_digits + 1
-        res = res .. "." .. s:sub(i, i) 
-    end
-
-    local nb_thousands = math.floor((len - 1) / 3)
-
-    return res .. units[1 + nb_thousands]
-end
+L.count_format_value = Utils.format_numeric_value
 
 local function destroy_slider_frame(event)
     local player = game.get_player(event.player_index)

--- a/scripts/caravan/gui/actions.lua
+++ b/scripts/caravan/gui/actions.lua
@@ -40,21 +40,21 @@ function P.build_action_flow(parent, caravan_data, action, tags)
             action.circuit_condition_left, action.circuit_condition_right = action.circuit_condition_right, action.circuit_condition_left
         end
 
-        comparator.build_circuit_static_comparator_widgets(flow, action, tags)
+        comparator.build_static_comparator_widgets(flow, action, tags, "signal")
     elseif Utils.contains({"load-caravan", "unload-caravan", "load-target", "unload-target"}, action.type) then
         -- don't know why we restrict comparison here, shouldn't it be a regular dropdown?
-        comparator.build_item_static_comparator_widgets(flow, action, tags, nil, "=")
+        comparator.build_static_comparator_widgets(flow, action, tags, "item", nil, "=")
         -- these are interrupt-only
     elseif Utils.contains({"food-count", "caravan-item-count", "target-item-count"}, action.type) then
         local filters
         if action.type == "food-count" then
             filters = {{filter = "name", name = Caravan.foods.all}}
         end
-        comparator.build_item_static_comparator_widgets(flow, action, tags, filters)
+        comparator.build_static_comparator_widgets(flow, action, tags, "item", filters)
     elseif action.type == "store-specific-food" then
         local filters = {{filter = "name", name = Caravan.foods.all}}
 
-        comparator.build_item_static_comparator_widgets(flow, action, tags, filters, "≥")
+        comparator.build_static_comparator_widgets(flow, action, tags, "item", filters, "≥")
     elseif Utils.contains({"at-outpost", "not-at-outpost"}, action.type) then
         flow.add {type = "sprite-button", name = "py_caravan_action_add_outpost", tags = tags, index = 1, style = "train_schedule_action_button", sprite = "utility/rename_icon"}
 

--- a/scripts/caravan/gui/cargo_tab.lua
+++ b/scripts/caravan/gui/cargo_tab.lua
@@ -1,3 +1,5 @@
+local Impl = require "__pyalienlife__/scripts/caravan/impl"
+local Utils = require "__pyalienlife__/scripts/caravan/utils"
 local inv = require "inventories"
 
 local P = {}
@@ -19,14 +21,53 @@ function P.build_inventory(parent, label, inventory_size)
     end
 end
 
+function P.build_fluid_flow(parent, caravan_data)
+    local flow = parent.add {type = "flow", name = "fluid_flow", direction = "horizontal"}
+    flow.style.bottom_padding = 8
+    flow.style.vertical_align = "center"
+    flow.style.horizontal_spacing = 8
+
+    local fluid = caravan_data.fluid
+
+    if fluid then
+        local sprite = "fluid/" .. fluid.name
+        local prototype = prototypes.fluid[fluid.name]
+        local label_caption = prototype.localised_name
+
+        if fluid.temperature > prototype.default_temperature then
+            label_caption = {"", prototype.localised_name, " (", math.floor(fluid.temperature), " °C)"}
+        end
+
+        local button = flow.add {type = "sprite-button", name = "fluid_sprite_button", style = "transparent_slot"}
+        button.sprite = sprite
+        button.elem_tooltip = {type = "fluid", name = fluid.name}
+
+        flow.add {type = "label", style = "clickable_squashable_label", caption = label_caption}
+        flow.add {type = "empty-widget"}.style.horizontally_stretchable = true
+        flow.add {type = "label", caption = Utils.format_numeric_value(fluid.amount), tooltip = tostring(fluid.amount)}
+        flow.add {type = "sprite-button", name = "py_caravan_flush_button", style = "tool_button_red", sprite = "utility/trash", tooltip = {"caravan-gui.flush-contents", prototype.localised_name}}
+    else
+        flow.style.horizontally_stretchable = true
+        flow.style.horizontal_align = "center"
+        flow.add {type = "label", style = "semibold_label", caption = "Empty"}
+        flow.add {type = "sprite-button", style = "transparent_slot"}.sprite = "utility/fluid_icon"
+    end
+end
+
 function P.build_cargo_flow(parent, player, caravan_data)
     local flow = parent.add {type = "flow", direction = "vertical", name = "cargo_flow"}
     flow.style.vertical_spacing = 8
     flow.add {type = "label", caption = "Food"}
     inv.build_fuel_inventory(flow, caravan_data)
     flow.add {type = "line", style = "inside_shallow_frame_with_padding_line"}.style.horizontally_stretchable = true
-    flow.add {type = "label", caption = "Caravan"}
-    inv.build_caravan_inventory(flow, caravan_data)
+
+    if caravan_data.entity.name == "fluidavan" then
+        flow.add {type = "label", caption = "Fluid tank"}
+        P.build_fluid_flow(flow, caravan_data)
+    else
+        flow.add {type = "label", caption = "Caravan"}
+        inv.build_caravan_inventory(flow, caravan_data)
+    end
     flow.add {type = "line", style = "inside_shallow_frame_with_padding_line"}.style.horizontally_stretchable = true
     flow.add {type = "label", caption = "Character"}
     inv.build_character_inventory(flow, player, caravan_data)
@@ -61,6 +102,17 @@ function P.update_cargo_pane(player)
 
     cargo_pane.cargo_flow.destroy()
     P.build_cargo_flow(cargo_pane, player, caravan_data)
+end
+
+gui_events[defines.events.on_gui_click]["py_caravan_flush_button"] = function(event)
+    local player = game.get_player(event.player_index)
+    local gui = player.gui.screen.caravan_gui
+    local unit_number = gui.tags.unit_number
+
+    local caravan = storage.caravans[unit_number]
+    caravan.fluid = nil
+    Impl.destroy_altmode_icon(caravan)
+    P.update_cargo_pane(player)
 end
 
 return P

--- a/scripts/caravan/gui/edit_interrupt.lua
+++ b/scripts/caravan/gui/edit_interrupt.lua
@@ -126,7 +126,8 @@ function P.build_action_list(parent, schedule_id)
         ActionGui.build_action(parent, nil, actions[i], tags)
     end
 
-    local valid_actions = Utils.get_valid_actions_for_entity("caravan", storage.edited_interrupt.schedule[schedule_id].entity)
+    local entity = storage.edited_interrupt.schedule[schedule_id].entity
+    local valid_actions = Utils.get_all_actions_for_entity(entity)
     local actions = table.map(table.invert(valid_actions), function(v) return {"caravan-actions." .. v, v} end)
 
     table.insert(actions, "+ Add action")

--- a/scripts/caravan/gui/interrupt_conditions.lua
+++ b/scripts/caravan/gui/interrupt_conditions.lua
@@ -31,11 +31,13 @@ function P.build_condition_flow(parent, condition, tags)
                 condition.circuit_condition_left, condition.circuit_condition_right = condition.circuit_condition_right, condition.circuit_condition_left
             end
             comparator.build_static_comparator_widgets(flow, condition, tags, "signal")
-        elseif Utils.contains({"food-count", "caravan-item-count", "target-item-count"}, condition.type) then
+        elseif Utils.contains({"food-count", "caravan-item-count", "target-item-count", "caravan-fluid-count", "target-fluid-count"}, condition.type) then
             local filters
             local elem_type = "item"
             if condition.type == "food-count" then
                 filters = {{filter = "name", name = Caravan.foods.all}}
+            elseif condition.type == "caravan-fluid-count" or condition.type == "target-fluid-count" then
+                elem_type = "fluid"
             end
             comparator.build_static_comparator_widgets(flow, condition, tags, elem_type, filters)
         end

--- a/scripts/caravan/gui/interrupt_conditions.lua
+++ b/scripts/caravan/gui/interrupt_conditions.lua
@@ -30,14 +30,14 @@ function P.build_condition_flow(parent, condition, tags)
             if type(condition.circuit_condition_left) == "number" then
                 condition.circuit_condition_left, condition.circuit_condition_right = condition.circuit_condition_right, condition.circuit_condition_left
             end
-
-            comparator.build_circuit_static_comparator_widgets(flow, condition, tags)
+            comparator.build_static_comparator_widgets(flow, condition, tags, "signal")
         elseif Utils.contains({"food-count", "caravan-item-count", "target-item-count"}, condition.type) then
             local filters
+            local elem_type = "item"
             if condition.type == "food-count" then
                 filters = {{filter = "name", name = Caravan.foods.all}}
             end
-            comparator.build_item_static_comparator_widgets(flow, condition, tags, filters)
+            comparator.build_static_comparator_widgets(flow, condition, tags, elem_type, filters)
         end
     end
 

--- a/scripts/caravan/gui/inventories.lua
+++ b/scripts/caravan/gui/inventories.lua
@@ -339,7 +339,9 @@ gui_events[defines.events.on_gui_click]["py_caravan_player_inventory_slot_."] = 
 
     handle_slot_click(event, caravan_data, inventory, caravan_data.inventory, pred)
 
-    P.update_caravan_inventory(player, caravan_data)
+    if caravan_data.entity.name ~= "fluidavan" then
+        P.update_caravan_inventory(player, caravan_data)
+    end
 end
 
 gui_events[defines.events.on_gui_click]["py_caravan_caravan_inventory_slot_."] = function(event)

--- a/scripts/caravan/gui/main_frame.lua
+++ b/scripts/caravan/gui/main_frame.lua
@@ -25,8 +25,12 @@ end
 
 function P.build_main_frame(parent, name, caravan_data)
     local main_frame = parent.add {type = "frame", direction = "vertical", name = name, tags = {unit_number = caravan_data.unit_number}}
-    -- enough to show the full cargo tab with starting inventory, without scroll bars
-    main_frame.style.height = 980
+    if caravan_data.entity.name == "fluidavan" then
+        main_frame.style.natural_height = 910
+    else
+        -- enough to show the full cargo tab with starting inventory, without scroll bars
+        main_frame.style.natural_height = 980
+    end
 
     P.build_title_bar_flow(main_frame, caravan_data)
 

--- a/scripts/caravan/impl/actions.lua
+++ b/scripts/caravan/impl/actions.lua
@@ -483,11 +483,11 @@ function P.target_item_count(caravan_data, schedule, action)
 end
 
 function P.is_inventory_full(caravan_data, schedule, action)
-    return caravan_data.inventory.is_full()
+    return (caravan_data.inventory and caravan_data.inventory.is_full()) or P.is_tank_full(caravan_data, schedule, action)
 end
 
 function P.is_inventory_empty(caravan_data, schedule, action)
-    return caravan_data.inventory.is_empty()
+    return (caravan_data.inventory == nil or caravan_data.inventory.is_empty()) or P.is_tank_empty(caravan_data, schedule, action)
 end
 
 function P.at_outpost(caravan_data, schedule, action)
@@ -573,11 +573,16 @@ end
 function P.caravan_fluid_count(caravan_data, schedule, action)
     local fluid_name = action.elem_value
 
-    local right = action.circuit_condition_right
-    if not right then return false end
+    if not fluid_name then return false end
 
-    if not caravan_data.fluid or caravan_data.fluid.name ~= fluid_name then return false end
-    local left = caravan_data.fluid.amount
+    local right = action.item_count or 0
+
+    local left
+    if not caravan_data.fluid or caravan_data.fluid.name ~= fluid_name then
+        left = 0
+    else
+        left = caravan_data.fluid.amount
+    end
 
     local operator = action.operator or 3
     if operator == 1 then
@@ -602,12 +607,16 @@ function P.target_fluid_count(caravan_data, schedule, action)
     if not outpost or not outpost.valid or outpost.fluids_count == 0 then return false end
     local fluid_name = action.elem_value
 
-    local right = action.circuit_condition_right
+    local right = action.item_count or 0
     if not right then return false end
 
+    local left
     local outpost_fluid = outpost.get_fluid(1)
-    if not outpost_fluid or outpost_fluid.name ~= fluid_name then return false end
-    local left = outpost_fluid.amount
+    if not outpost_fluid or outpost_fluid.name ~= fluid_name then
+        left = 0
+    else
+        left = outpost_fluid.amount
+    end
 
     local operator = action.operator or 3
     if operator == 1 then

--- a/scripts/caravan/impl/actions.lua
+++ b/scripts/caravan/impl/actions.lua
@@ -529,7 +529,7 @@ function P.fill_tank(caravan_data, schedule, action)
 
     local completed = action.async or output.amount >= total_output_volume
     if amount_to_transfer > 0 and completed then
-        P.eat(caravan_data)
+        ImplControl.eat(caravan_data)
     end
     return completed
 end
@@ -557,7 +557,7 @@ function P.empty_tank(caravan_data, schedule, action)
 
     local completed = action.async or input.amount == 0
     if amount_transfered > 0 and completed then
-        P.eat(caravan_data)
+        ImplControl.eat(caravan_data)
     end
     return completed
 end

--- a/scripts/caravan/utils.lua
+++ b/scripts/caravan/utils.lua
@@ -22,6 +22,22 @@ function P.get_valid_actions_for_entity(caravan_entity_name, entity)
     return valid_actions or all_actions.default or error()
 end
 
+function P.get_all_actions_for_entity(entity)
+    local all_actions = Caravan.all_actions
+    local valid_actions
+    if entity and entity.valid then
+        if entity.name == "outpost" or entity.name == "outpost-aerial" then
+            valid_actions = all_actions.outpost
+        elseif entity.name == "fluid-outpost" then
+            valid_actions = all_actions["fluid-outpost"]
+        else
+            valid_actions = all_actions[entity.type]
+        end
+    end
+
+    return valid_actions or all_actions.default or error()
+end
+
 function P.get_name(caravan_data)
     local name = caravan_data.name
     if name and name ~= "" then return name end

--- a/scripts/caravan/utils.lua
+++ b/scripts/caravan/utils.lua
@@ -245,4 +245,24 @@ function P.rename_interrupt(interrupt, new_name)
     end
 end
 
+function P.format_numeric_value(v)
+    local s = tostring(v)
+    local len = string.len(s)
+
+    local units = {"", "k", "M", "G"}
+
+    local remainder = len % 3
+    local nb_fractional_digits = remainder == 0 and 3 or remainder
+    local res = s:sub(1, nb_fractional_digits)
+
+    if len > 1 and nb_fractional_digits == 1 then
+        local i = nb_fractional_digits + 1
+        res = res .. "." .. s:sub(i, i)
+    end
+
+    local nb_thousands = math.floor((len - 1) / 3)
+
+    return res .. units[1 + nb_thousands]
+end
+
 return P

--- a/scripts/caravan/utils.lua
+++ b/scripts/caravan/utils.lua
@@ -129,7 +129,7 @@ function P.convert_to_tooltip_row(item)
     return {"", "\n[item=" .. name .. ",quality=" .. quality .. "] ", " ×", count}
 end
 
-function P.get_inventory_tooltip(caravan_data)
+local function get_caravan_inventory_tooltip(caravan_data)
     local inventory = caravan_data.inventory
     ---@type (table | string)[]
     local inventory_contents = {"", "\n[img=utility/trash_white] ", {"caravan-gui.the-inventory-is-empty"}}
@@ -151,6 +151,22 @@ function P.get_inventory_tooltip(caravan_data)
         end
     end
     return {"", "[font=default-semibold]", inventory_contents, "[/font]"}
+end
+
+local function get_fluidavan_inventory_tooltip(caravan_data)
+    if caravan_data.fluid then
+        return {"", "\n[fluid=" .. caravan_data.fluid.name .. "] ", " ×", caravan_data.fluid.amount}
+    else
+        return {"", "\n[img=utility/fluid_icon] ", {"caravan-gui.tank-is-empty"}}
+    end
+end
+
+function P.get_inventory_tooltip(caravan_data)
+    game.print(caravan_data.entity.name)
+    if caravan_data.entity.name == "fluidavan" then
+        return get_fluidavan_inventory_tooltip(caravan_data)
+    end
+    return get_caravan_inventory_tooltip(caravan_data)
 end
 
 function P.get_summary_tooltip(caravan_data)

--- a/settings.lua
+++ b/settings.lua
@@ -1,1 +1,6 @@
-do return end
+data:extend {{
+        type = "bool-setting",
+        name = "py-enable-fluid-caravans",
+        default_value = false,
+        setting_type = "startup"
+}}


### PR DESCRIPTION
Hello,

This PR allows transporting fluids between fluid caravans and their fluid outposts.

The idea stemmed from me not wanting to use trains, being tired of having pipe spaghetti everywhere, and biofluid network being gated behind chem science. It thus felt natural to use caravans.

Fluid temperature is shown if it is greater than the default temperature, temp mixing is also implemented.

I've had to set the `inventory_size` at 0, in order to open the character inventory, to put food in the caravan.
It results in a tiny rectangle in the GUI (see attached screenshot).

## Assets

"New" icons are attached, as I don't have access to the `pyalienlifegraphics2` repo.

Ideally, a storage tank would be attached on the caravan's back, but I've put my whole graphical skills into making the icons,
so I've recycled the current caravan/outpost assets as placeholders.

![fluid-caravan](https://github.com/user-attachments/assets/acfb0f96-8c95-4a7a-a9b0-1e61266a1c2a)
![fluid-outpost](https://github.com/user-attachments/assets/5fd3ba08-4c5e-4463-a141-9459c7fa6e25)

## Balance

I've arbitrarily added the `py-tank-4` as an ingredient for both the caravan and outpost. In my playthrough, it's the one I used the most thanks to the absence of Duralumin. Should the volume capacity be nerfed?

Two pumps are also part of the caravan recipe, to somewhat justify the instant transfer.

Foods are the same for fluid and regular caravans, but Cotonou suggested that we could require better foods for the fluid ones.

## Screenshots

![image](https://github.com/user-attachments/assets/f9da3d0b-bf02-4f75-ad82-668aa9f42266)
![image](https://github.com/user-attachments/assets/4085b786-44f0-4315-a2ed-7c6f59f44400)
![image](https://github.com/user-attachments/assets/d854eb6e-a4bc-44b8-a9c0-7bddbb88c85f)