### PR TITLE
Revert "caravan: do not consume food when destination is unavailable"

### DIFF
--- a/scripts/caravan/caravan.lua
+++ b/scripts/caravan/caravan.lua
@@ -788,11 +788,6 @@ end
 ---@param schedule_id int
 ---@param skip_eating boolean?
 local function begin_schedule(caravan_data, schedule_id, skip_eating)
-    local schedule = caravan_data.schedule[schedule_id]
-    if not schedule or (schedule.entity and not schedule.entity.valid) then
-        stop_actions(caravan_data); return
-    end
-
     if caravan_data.last_scheduled_tick and caravan_data.last_scheduled_tick + 30 > game.tick then
         if caravan_data.schedule_id ~= schedule_id then
             if not skip_eating and not Caravan.eat(caravan_data) then
@@ -808,11 +803,14 @@ local function begin_schedule(caravan_data, schedule_id, skip_eating)
     if not entity or not entity.valid then
         stop_actions(caravan_data); return
     end
-
+    local schedule = caravan_data.schedule[schedule_id]
     if caravan_data.fuel_inventory then
         if not skip_eating and not Caravan.eat(caravan_data) then
             stop_actions(caravan_data); return
         end
+    end
+    if not schedule then
+        stop_actions(caravan_data); return
     end
 
     caravan_data.schedule_id = schedule_id


### PR DESCRIPTION
Reverts pyanodon/pyalienlife#338

<https://github.com/pyanodon/pyalienlife/commit/2de45eb0c25d80c0027d93c1427572a7f4a57a16>
> If an entity is invalid, the actions shouldn't be stopped, or else caravans referencing the player will stop pemanently until manually started. This was intentional behaviour broken in that commit.