### PR TITLE
Fix TURD recipe re-lock after reset_technology_effects

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -9,6 +9,7 @@ Date: ???
     - Fixed mining a entity in a caravan's schedule did not update the caravan GUI with "Destination is unavailable. Click here to reassign it.".
     - Fixed caravan GUI crash after clicking the ground while in the "Destination is unavailable. Click here to reassign it." state. Resolves https://github.com/pyanodon/pybugreports/issues/1113
     - Fixed re-assigning to the player whilst in the "Destination is unavailable. Click here to reassign it." state would only keep track of the player entity, and not the player controller. (relevant if the player dies or turns into a horse-man)
+    - Fixed TURD recipes becoming locked after another mod triggers reset_technology_effects
 ---------------------------------------------------------------------------------------------------
 Version: 3.0.47
 Date: 2025-7-20

--- a/scripts/turd/turd.lua
+++ b/scripts/turd/turd.lua
@@ -556,6 +556,11 @@ py.on_event(py.events.on_init(), function()
     clear_new_turd_recipe_notifications()
 end)
 
+-- If we don't handle this, a force.reset_technology_effects() will lock all TURD recipes until a technology is researched
+py.on_event(defines.events.on_technology_effects_reset, function(event)
+    reapply_turd_bonuses(event.force)
+end)
+
 local function starts_with(str, start)
     return str:sub(1, #start) == start
 end


### PR DESCRIPTION
Another mod triggering `force.reset_technology_effects()` would result in TURD recipes being re-locked until a technology is researched.