### PR TITLE
Added a TURD sign to the icons of TURD building recipes (i.e. arquad path 2) so they're easier to differentiate in a GUI

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -6,6 +6,7 @@ Date: ???
     - Invalid food items (including spoil results) in the dig site will now be ejected to trash slots. Resolves https://github.com/pyanodon/pybugreports/issues/1110
     - Fixed a potential crash in interrupts migrations
     - Added a TURD sign to the icons of TURD buildings so they're easier to differentiate in a GUI. Resolves https://github.com/pyanodon/pybugreports/issues/1107
+    - Added a TURD sign to the icons of TURD building recipes (i.e. arquad path 2) so they're easier to differentiate in a GUI
     - Fixed a potential crash in interrupts migrations.
     - Caravan GUI has been remade. Should now be more responsive and nicer to use. https://github.com/pyanodon/pyalienlife/pull/329
     - Fixed mining a entity in a caravan's schedule did not update the caravan GUI with "Destination is unavailable. Click here to reassign it.".

--- a/prototypes/turd.lua
+++ b/prototypes/turd.lua
@@ -204,6 +204,40 @@ local function build_tech_upgrade(tech_upgrade)
                 recipes_with_turd_description[effect.recipe] = true
             elseif effect.type == "recipe-replacement" and data.raw.recipe[effect.new] then
                 py.add_to_description("recipe", data.raw.recipe[effect.new], {"turd.font", {"turd.recipe-replacement"}})
+                local recipe = data.raw.recipe[effect.new]
+                if recipe then
+                    local main_product = data.raw.item[recipe.main_product or #recipe.results == 1 and recipe.results[1].name] or {}
+                    if main_product.place_result then
+                        recipe.icons = (recipe.icon or main_product.icon) and {{
+                          icon = recipe.icon or main_product.icon,
+                          icon_size = recipe.icon_size or main_product.icon_size
+                        }} or recipe.icons or main_product.icons
+                        recipe.icons[#recipe.icons+1] = {
+                            icon = "__pycoalprocessinggraphics__/graphics/icons/gui/turd.png",
+                            shift = {14, -6},
+                            scale = 0.35,
+                            floating = true
+                        }
+                        recipe.icon = nil
+                        recipe.icon_size = nil
+                    end
+                end
+            elseif effect.type == "machine-replacement" then
+                local machine = data.raw["assembling-machine"][effect.new] or data.raw.furnace[effect.new] or data.raw["burner-generator"][effect.new]
+                if machine then
+                    machine.icons = machine.icons or {{
+                        icon = machine.icon,
+                        icon_size = machine.icon_size
+                    }}
+                    machine.icons[#machine.icons + 1] = {
+                        icon = "__pycoalprocessinggraphics__/graphics/icons/gui/turd.png",
+                        shift = {14, -6},
+                        scale = 0.35,
+                        floating = true
+                    }
+                    machine.icon = nil
+                    machine.icon_size = nil
+                end
             end
         end
     end

--- a/prototypes/upgrades/auog.lua
+++ b/prototypes/upgrades/auog.lua
@@ -60,20 +60,6 @@ if data and not yafc_turd_integration then
     buffed_generator.localised_description = buffed_generator.localised_description or {"entity-description." .. buffed_generator.name}
     buffed_generator.placeable_by = {item = buffed_generator.name, count = 1}
     buffed_generator.localised_name = {"entity-name." .. buffed_generator.name}
-    buffed_generator.icons = {
-        {
-            icon = buffed_generator.icon,
-            icon_size = buffed_generator.icon_size
-        },
-        {
-            icon = "__pycoalprocessinggraphics__/graphics/icons/gui/turd.png",
-            shift = {14, -6},
-            scale = 0.35,
-            floating = true
-        }
-    }
-    buffed_generator.icon = nil
-    buffed_generator.icon_size = nil
     buffed_generator.subgroup = data.raw.item[buffed_generator.name].subgroup
     buffed_generator.order = data.raw.item[buffed_generator.name].order
     buffed_generator.name = buffed_generator.name .. "-turd"

--- a/prototypes/upgrades/bioreactor.lua
+++ b/prototypes/upgrades/bioreactor.lua
@@ -43,20 +43,6 @@ if data and not yafc_turd_integration then
             entity.localised_name = {"entity-name." .. name}
             entity.placeable_by = {item = name, count = 1}
             entity.localised_description = entity.localised_description or {"entity-description." .. name}
-            entity.icons = {
-                {
-                    icon = entity.icon,
-                    icon_size = entity.icon_size
-                },
-                {
-                    icon = "__pycoalprocessinggraphics__/graphics/icons/gui/turd.png",
-                    shift = {14, -6},
-                    scale = 0.35,
-                    floating = true
-                }
-            }
-            entity.icon = nil
-            entity.icon_size = nil
             table.insert(entity.flags, "not-in-made-in")
             entity.energy_source = {
                 type = "burner",

--- a/prototypes/upgrades/compost.lua
+++ b/prototypes/upgrades/compost.lua
@@ -18,20 +18,6 @@ if data and not yafc_turd_integration then
             }
         }
         entity.localised_description = entity.localised_description or {"entity-description." .. name}
-        entity.icons = {
-            {
-                icon = entity.icon,
-                icon_size = entity.icon_size
-            },
-            {
-                icon = "__pycoalprocessinggraphics__/graphics/icons/gui/turd.png",
-                shift = {14, -6},
-                scale = 0.35,
-                floating = true
-            }
-        }
-        entity.icon = nil
-        entity.icon_size = nil
         table.insert(entity.flags, "not-in-made-in")
         entity.energy_source = {
             type = "fluid",

--- a/prototypes/upgrades/fish.lua
+++ b/prototypes/upgrades/fish.lua
@@ -59,20 +59,6 @@ local function add_new_fish_farm(i)
     entity.localised_name = {"entity-name." .. name}
     entity.placeable_by = {item = name, count = 1}
     entity.localised_description = entity.localised_description or {"entity-description." .. name}
-    entity.icons = {
-        {
-            icon = entity.icon,
-            icon_size = entity.icon_size
-        },
-        {
-            icon = "__pycoalprocessinggraphics__/graphics/icons/gui/turd.png",
-            shift = {14, -6},
-            scale = 0.35,
-            floating = true
-        }
-    }
-    entity.icon = nil
-    entity.icon_size = nil
     entity.subgroup = data.raw.item[name].subgroup
     entity.order = data.raw.item[name].order
     if i ~= 4 then entity.next_upgrade = "turd-fish-farm-mk0" .. (i + 1) end

--- a/prototypes/upgrades/wpu.lua
+++ b/prototypes/upgrades/wpu.lua
@@ -92,20 +92,6 @@ if data and not yafc_turd_integration then
         local entity = table.deepcopy(data.raw["assembling-machine"][name])
         entity.name = "turd-" .. name
         entity.localised_name = {"entity-name." .. name}
-        entity.icons = {
-            {
-                icon = entity.icon,
-                icon_size = entity.icon_size
-            },
-            {
-                icon = "__pycoalprocessinggraphics__/graphics/icons/gui/turd.png",
-                shift = {14, -6},
-                scale = 0.35,
-                floating = true
-            }
-        }
-        entity.icon = nil
-        entity.icon_size = nil
         entity.placeable_by = {item = name, count = 1}
         entity.localised_description = entity.localised_description or {"entity-description." .. name}
         entity.subgroup = data.raw.item[name].subgroup


### PR DESCRIPTION
Centralized TURD building icon code for easier expansion and modification