### PR TITLE
Caravan/interrupt fixes

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -20,6 +20,7 @@ Date: ???
     - TURD selection seach now respects locale. Resolves https://github.com/pyanodon/pybugreports/issues/669
     - Fixed dig sites not respecting control behavior (circuit enable/disable)
     - Fixed that caravan food would allow 1 more action per food item than intended.
+    - Fixed many caravan interrupts quirks. They now behave like train interrupts.
 ---------------------------------------------------------------------------------------------------
 Version: 3.0.47
 Date: 2025-7-20

--- a/scripts/caravan/event-handlers/global.lua
+++ b/scripts/caravan/event-handlers/global.lua
@@ -325,8 +325,6 @@ py.register_on_nth_tick(60, "update-caravans", "pyal", function()
             caravan_data.retry_pathfinder = caravan_data.retry_pathfinder - 1
             if caravan_data.retry_pathfinder == 0 then
                 CaravanImpl.begin_schedule(caravan_data, caravan_data.schedule_id, true)
-            end
-            if caravan_data.retry_pathfinder == 0 then
                 caravan_data.retry_pathfinder = nil
             end
             goto continue
@@ -354,6 +352,7 @@ py.register_on_nth_tick(60, "update-caravans", "pyal", function()
         elseif result then
             if #schedule.actions == caravan_data.action_id then
                 CaravanImpl.advance_caravan_schedule_by_1(caravan_data)
+                CaravanImpl.begin_schedule(caravan_data, caravan_data.schedule_id, #caravan_data.schedule == 1)
             else
                 CaravanImpl.begin_action(caravan_data, caravan_data.action_id + 1)
             end

--- a/scripts/caravan/test/test_plan.md
+++ b/scripts/caravan/test/test_plan.md
@@ -1,0 +1,340 @@
+Preconditions:
+##############
+
+- each scenario starts on a full state reset (i.e. reloading the save)
+
+Case 1, infinite interrupt:
+===========================
+
+Scenario a:
+-----------
+
+- Click play on 'Case1-Stop1'
+
+Expected behaviour:
+
+- 'Case1-InterruptStop1' is at the top of the schedule, and stays stuck.
+
+Scenario b:
+-----------
+
+- Click play on 'Case1-Stop2'
+
+Expected behaviour:
+
+- 'Case1-InterruptStop1' is inserted between 'Case1-Stop1' and 'Case1-Stop2', and stays stuck on 'Case1-InterruptStop1'.
+
+Scenario c:
+-----------
+
+- Click play on 'Case1-Stop1'
+- Click play on 'Case1-Stop1' again
+
+Expected behaviour:
+
+- Caravan goes to 'Case1-Stop1', then 'Case1-Stop2', then on 'Case1-InterruptStop1', and stays stuck.
+
+Scenario d:
+-----------
+
+- Click play on 'Case1-Stop1'
+- Click play on 'Case1-Stop1' again
+- Delete 'Case1-InterruptStop1'
+
+Expected behaviour:
+
+- Caravan goes to Case1-Stop1
+- 'Case1-InterruptStop1' is inserted between 'Case1-Stop1' and 'Case1-Stop2', and stays stuck.
+
+Scenario e:
+-----------
+
+- Click play on 'Case1-Stop1'
+- Delete 'Case1-InterruptStop1'
+
+Expected behaviour:
+
+- Caravan goes to 'Case1-Stop1'
+- 'Case1-InterruptStop1' is inserted between 'Case1-Stop1' and 'Case1-Stop2'.
+- Caravan goes to 'Case1-InterruptStop1' and stays stuck.
+
+Scenario f:
+-----------
+
+- Click play on 'Case1-Stop1'
+- Drag 'Case1-InterruptStop1' to the bottom of the schedule.
+
+Expected behaviour:
+
+- After 5s, 'Case1-InterruptStop1' goes to the top of the schedule, and stays stuck.
+
+Scenario g:
+-----------
+
+- Click play on 'Case1-Interrupt1'
+
+Expected behaviour:
+
+- 'Case1-InterruptStop1' is inserted between 'Case1-Stop1' and 'Case1-Stop2', and stays stuck.
+
+Scenario h:
+-----------
+
+- Click play on 'Case1-Stop1'
+- Click play on 'Case1-Stop1' again
+- Click play on 'Case1-Stop1' yet again (to pause the schedule)
+- Click play on 'Case1-Interrupt1'
+
+Expected behaviour:
+
+- 'Case1-InterruptStop1' is inserted between 'Case1-Stop1' and 'Case1-Stop2'.
+
+Scenario i:
+-----------
+
+- Click play on 'Case1-Stop2'
+- Click play on 'Case1-Stop2' again
+- Click play on 'Case1-Stop2' yet again (to pause the schedule)
+- Click play on 'Case1-Interrupt1'
+
+Expected behaviour:
+
+- 'Case1-InterruptStop1' stays in-place and is stuck.
+
+Scenario j:
+-----------
+
+- Edit 'Case1-Interrupt1'
+- Remove all targets
+- Save interrupt
+- Click play on 'Case1-Stop1'
+
+Expected behaviour:
+
+- Caravan goes to 'Case1-Stop1'
+- Caravan goes to 'Case1-Stop2'
+- Repeats above steps
+
+Scenario k:
+-----------
+
+- Edit 'Case1-Interrupt1'
+- Remove all targets
+- Save interrupt
+- Click play on 'Case1-Interrupt1'
+
+Expected behaviour:
+
+- Nothing happens
+
+Scenario l:
+-----------
+
+- Edit interrupt 'Case1-Interrupt1'
+- Toggle 'Allow interrupting other interrupts' checkbox.
+- Save interrupt
+- Click play on 'Case1-Stop1'
+- Click play on 'Case1-Stop1' again
+
+Expected behaviour:
+
+- Caravan goes to 'Case1-Stop1'
+- 'Case1-InterruptStop1' is inserted between 'Case1-Stop1' and 'Case1-Stop2', and stays stuck on 'Case1-InterruptStop1'.
+
+Scenario m:
+-----------
+
+- Edit interrupt 'Case1-Interrupt1'
+- Toggle 'Allow interrupting other interrupts' checkbox.
+- Save interrupt
+- Click play on 'Case1-Stop1'
+- Click play on 'Case1-Stop2'
+
+Expected behaviour:
+
+- Caravan goes to 'Case1-Stop2'
+- 'Case1-InterruptStop1' is inserted at the bottom of the schedule, triggers once, moves to the top of the schedule, and stays stuck.
+
+Scenario n:
+-----------
+
+- Click play on 'Case1-Stop1'
+- Click play on 'Case1-Interrupt1'
+
+Expected behaviour:
+
+- 'Case1-InterruptStop1' stays at the same place in the schedule
+- Caravan goes to 'Case1-InterruptStop1' and stays stuck.
+
+Scenario o:
+-----------
+
+- Click play on 'Case1-Stop2'
+- Click play on 'Case1-Interrupt1'
+
+Expected behaviour:
+
+- 'Case1-InterruptStop1' stays at the same place in the schedule
+- Caravan goes to 'Case1-InterruptStop1' and stays stuck.
+
+Scenario p:
+-----------
+
+- Click play on 'Case1-Stop2'
+- Click play on 'Case1-Stop2' again
+- Click play on 'Case1-Interrupt1'
+
+Expected behaviour:
+
+- 'Case1-InterruptStop1' moves at the bottom of the schedule, executes once, moves to the top of the schedule and stays stuck.
+
+Case 2, finite interrupt with one destination:
+==============================================
+
+Scenario a:
+-----------
+
+- Click play on 'Case2-Stop1'
+
+Expected behaviour:
+
+- Caravan goes to 'Case2-Stop1'
+- Caravan goes to 'Case2-Stop2'
+- 'Case2-InterruptStop1' is inserted at the bottom of the schedule
+- Caravan goes to 'Case2-InterruptStop1'
+- 'Case2-InterruptStop1' is deleted from the schedule
+- Repeats previous steps
+
+Scenario b:
+-----------
+
+- Click play on 'Case2-Interrupt1'
+
+Expected behaviour:
+
+- 'Case2-InterruptStop1' is inserted between 'Case2-Stop1' and 'Case2-Stop2'
+- Caravan goes to 'Case2-InterruptStop1'
+- 'Case2-InterruptStop1' is deleted from the schedule
+- Caravan goes to 'Case2-Stop2'
+- 'Case2-InterruptStop1' is inserted at the bottom of the schedule
+- Caravan goes to 'Case2-InterruptStop1'
+- 'Case2-InterruptStop1' is deleted from the schedule
+- Repeats Scenario a
+
+Scenario c:
+-----------
+
+- Click play on 'Case2-Interrupt1'
+- Click play on 'Case2-Stop2'
+
+Expected behaviour:
+
+- Caravan goes to 'Case2-Stop2', then on 'Case2-Stop1', then on 'Case2-InterruptStop1'
+- 'Case2-InterruptStop1' is deleted from the schedule
+- Caravan goes to 'Case2-Stop2'
+- 'Case2-InterruptStop1' is inserted at the bottom of the schedule
+- Caravan goes to 'Case2-InterruptStop1'
+- 'Case2-InterruptStop1' is deleted from the schedule
+- Repeats Scenario a
+
+Scenario d:
+-----------
+
+- Click play on 'Case2-Interrupt1'
+- Click play on 'Case2-Stop2'
+- Click play on 'Case2-Interrupt1'
+
+Expected behaviour:
+
+- 'Case2-InterruptStop1' is moved at the bottom of the schedule
+- Caravan goes to 'Case2-InterruptStop1'
+- 'Case2-InterruptStop1' is deleted from the schedule
+- Caravan goes to 'Case2-Stop1'
+- Repeats Scenario a
+
+Scenario e:
+-----------
+
+- Edit 'Case2-Interrupt1'
+- Toggle 'Allow interrupting other interrupts' checkbox.
+- Save interrupt
+- Click play on 'Case2-Interrupt1'
+- Click play on 'Case2-Stop2'
+
+Expected behaviour:
+
+- Caravan goes to 'Case2-Stop2'
+- 'Case2-InterruptStop1' is moved at the bottom of the schedule
+- Caravan goes to 'Case2-InterruptStop1'
+- 'Case2-InterruptStop1' is deleted from the schedule
+- Caravan goes to 'Case2-Stop1'
+- Repeats Scenario a
+
+Case 3, two finite interrupts
+=============================
+
+Scenario a:
+-----------
+
+- Click play on 'Case3-Stop1'
+
+Expected behaviour:
+
+- Caravan goes to 'Case3-Stop1'
+- Caravan goes to 'Case3-Stop2'
+- 'Case3-InterruptStop1' and 'Case3-InterruptStop2' are inserted at the bottom of the schedule
+- Caravan goes to 'Case3-InterruptStop1'
+- 'Case3-InterruptStop1' is deleted from the schedule
+- Caravan goes to 'Case3-InterruptStop2'
+- 'Case3-InterruptStop2' is deleted from the schedule
+- Repeat above steps
+
+Scenario b:
+-----------
+
+- Click play on 'Case3-Stop1'
+- Wait for caravan to leave 'Case3-InterruptStop1'
+- Click play on 'Case3-Interrupt1'
+
+Expected behaviour:
+
+- 'Case3-InterruptStop2' is replaced by 'Case3-InterruptStop1' and 'Case3-InterruptStop2'
+- Caravan goes to 'Case3-InterruptStop1'
+- Caravan goes to 'Case3-InterruptStop2'
+- Caravan goes to 'Case3-Stop1'
+- Repeats Scenario a
+
+Scenario c:
+-----------
+
+- Edit 'Case3-Interrupt2'
+- Toggle 'Allow interrupting other interrupts' checkbox.
+- Save interrupt
+- Click play on 'Case3-Stop1'
+
+Expected behaviour:
+
+- Caravan goes to 'Case3-Stop1'
+- Caravan goes to 'Case3-Stop2'
+- 'Case3-InterruptStop1' and 'Case3-InterruptStop2' are inserted at the bottom of the schedule
+- Caravan goes to 'Case3-InterruptStop1'
+- 'Case3-InterruptStop2' is replaced by 'Case3-InterruptStop3'
+- Caravan goes to 'Case3-InterruptStop3'
+- 'Case3-InterruptStop3' is deleted from the schedule
+- Caravan goes to 'Case3-Stop1'
+- Repeats above steps
+
+Case 4, no schedule
+===================
+
+Scenario a
+----------
+
+- Click play on 'Case4-Interrupt1'
+
+Expected behaviour:
+
+- 'Case4-InterruptStop1' is the only destination in the schedule
+- Caravan goes to 'Case4-InterruptStop1'
+- 'Case4-InterruptStop1' is deleted from the schedule
+- Caravan is idle


### PR DESCRIPTION
This PR aligns caravan behaviour with trains.

I've also added a basic QA test plan, that can be augmented each time a bug is found. The scenario I used to execute the plan is also attached.

For each test case, there is a specific train-caravan setup (1 at the top, 4 at the bottom), to be able to see how trains behave.

This should make future refactors/fixes to the caravan logic code easier, and reduce the number of bugs introduced.

Test results on current master branch: [test_run_master.txt](https://github.com/user-attachments/files/21552708/test_run_master.txt)

[Train - caravan interrupts comparison.zip](https://github.com/user-attachments/files/21552779/Train.-.caravan.interrupts.comparison.zip)

