### PR TITLE
Fix caravan food allows 1 more action per food item than intended

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -18,6 +18,7 @@ Date: ???
     - Fixed that you could place a normal entity when you have an entity-replacing TURD selected
     - Fixed Bulk Inserter 1 and 2 technologies not having the correct prerequesites and dependants. Resolves https://github.com/pyanodon/pybugreports/issues/1086 and https://github.com/pyanodon/pybugreports/issues/1099
     - TURD selection seach now respects locale. Resolves https://github.com/pyanodon/pybugreports/issues/669
+    - Fixed that caravan food would allow 1 more action per food item than intended.
 ---------------------------------------------------------------------------------------------------
 Version: 3.0.47
 Date: 2025-7-20

--- a/scripts/caravan/gui/inventories.lua
+++ b/scripts/caravan/gui/inventories.lua
@@ -116,10 +116,6 @@ local function build_fuel_inventory_flow(parent, caravan_data, fuel_inventory, n
 
     local flow = build_inventory_flow(parent, fuel_inventory, name, tags, {sprite = "slot_icon_food", tooltip = favorite_food_tooltip})
     local bar = flow.add {type = "progressbar", style = "burning_progressbar"}
-    -- FIXME with 2 auog's food, I have 11 actions total, instead of 8
-    -- for some reason the fuel bar is full when the caravan is idle
-    -- beginning the schedule burns the full bar, but doesn't start burning a food
-    -- it's broken on master too, let's fix it later
     bar.value = caravan_data.fuel_bar / caravan_data.last_eaten_fuel_value
     bar.style.horizontally_stretchable = true
     bar.style.right_margin = 8

--- a/scripts/caravan/impl.lua
+++ b/scripts/caravan/impl.lua
@@ -281,7 +281,7 @@ function P.is_automated(caravan_data)
     return caravan_data.schedule_id and caravan_data.schedule_id >= 0
 end
 
----Reduces the fuel bar of the caravan by 1. If the fuel bar is empty, it will instead attempt to eat fuel from the fuel inventory.
+---Reduces the fuel bar of the caravan by 1. If the fuel bar is empty, it will also attempt to refill it using fuel from the fuel inventory.
 ---If this function returns false, the caravan is starved and all actions stop.
 ---@param caravan_data Caravan
 ---@return boolean
@@ -295,6 +295,7 @@ function P.eat(caravan_data)
             caravan_data.fuel_bar = caravan_prototypes[entity.name].favorite_foods[item]
             caravan_data.last_eaten_fuel_value = caravan_data.fuel_bar
             entity.force.get_item_production_statistics(entity.surface_index).on_flow(item, -1)
+            caravan_data.fuel_bar = caravan_data.fuel_bar - 1
             return true
         end
         return false


### PR DESCRIPTION
e.g. jerky gives 2 actions instead of 1, brains give 3 actions instead of 2, etc.

This is because when the caravan's "stomach" is empty and it was asked to eat, the caravan would load a new food item but not actually use any fuel.