### PR TITLE
caravan: prevent crash when no character is attached to the player

### DIFF
--- a/scripts/caravan/gui/inventories.lua
+++ b/scripts/caravan/gui/inventories.lua
@@ -384,6 +384,7 @@ py.on_event(defines.events.on_player_cursor_stack_changed, function (event)
     local player = game.get_player(event.player_index)
     local gui = player.gui.screen.caravan_gui
     if not gui then return end
+    if player.controller_type ~= defines.controllers.character then return end
 
     if player.cursor_stack.count > 0 then return end
     player.hand_location = nil


### PR DESCRIPTION
Fixes https://github.com/pyanodon/pybugreports/issues/1122

The cargo tab's contents are only built when `player.controller_type == defines.controllers.character`, so attempting to refresh them crashed.