### PR TITLE
Don't open caravan GUI when trying to place a building

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -22,6 +22,7 @@ Date: ???
     - Fixed that caravan food would allow 1 more action per food item than intended.
     - Fixed many caravan interrupts quirks. They now behave like train interrupts.
     - Added and/or buttons to caravan's interrupt conditions
+    - Clicking on a caravan while trying to place a building will no longer open the caravan GUI (just like vanilla GUIs).
 ---------------------------------------------------------------------------------------------------
 Version: 3.0.47
 Date: 2025-7-20

--- a/scripts/caravan/event-handlers/global.lua
+++ b/scripts/caravan/event-handlers/global.lua
@@ -227,8 +227,10 @@ py.on_event(py.events.on_entity_clicked(), function(event)
     local player = game.get_player(event.player_index) --[[@as LuaPlayer]]
     -- If the player has a temporary item in their cursor, we don't let them open the GUI
     -- This includes the caravan controller, blueprint tool, etc
+    -- Also if the player has a buildable item in their cursor, we don't open the GUI (This mimics vanilla GUI behavior)
     local stack = player.cursor_stack
-    if stack and stack.valid_for_read and stack.prototype.has_flag("only-in-cursor") then
+    if stack and stack.valid_for_read
+       and (stack.prototype.has_flag("only-in-cursor") or stack.prototype.place_result ~= nil) then
         return
     end
     local entity = player.selected


### PR DESCRIPTION
This kept bothering me when accidentally clicking near my mule.

<img width="1598" height="1480" alt="Screenshot from 2025-08-05 18-21-17" src="https://github.com/user-attachments/assets/07a52a8e-da9a-40df-8f4e-4edb1bd3ab05" />
