### PR TITLE
Hide disabled recipes for bonemeal and bonemeal-salt.

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -24,6 +24,7 @@ Date: ???
     - Fixed many caravan interrupts quirks. They now behave like train interrupts.
     - Added and/or buttons to caravan's interrupt conditions
     - Clicking on a caravan while trying to place a building will no longer open the caravan GUI (just like vanilla GUIs).
+    - Hide some disabled bone meal recipes. Resolves https://github.com/pyanodon/pybugreports/issues/1126
 ---------------------------------------------------------------------------------------------------
 Version: 3.0.47
 Date: 2025-7-20

--- a/prototypes/updates/pycoalprocessing-updates.lua
+++ b/prototypes/updates/pycoalprocessing-updates.lua
@@ -62,7 +62,7 @@ data.raw.lab.lab.allowed_module_categories = {"vatbrain"}
 
 --RECIPES--
 RECIPE("ralesia"):remove_unlock("ralesia")
-RECIPE("bonemeal"):remove_unlock("ulric")
+RECIPE("bonemeal"):remove_unlock("ulric"):set_fields {hidden = true}
 RECIPE("coal-fawogae"):remove_unlock("coal-processing-1"):add_unlock("fawogae-mk01")
 
 RECIPE("automated-factory-mk01"):remove_unlock("fast-inserter"):add_unlock("automation-2")

--- a/prototypes/updates/pyrawores-updates.lua
+++ b/prototypes/updates/pyrawores-updates.lua
@@ -105,7 +105,7 @@ RECIPE("chemical-plant-mk01"):remove_unlock("filtration"):add_unlock("electric-e
 RECIPE("compressor-mk01"):remove_unlock("nitrogen-mk02")
 
 RECIPE("mukmoux-fat-salt"):remove_unlock("mukmoux")
-RECIPE("bonemeal-salt"):remove_unlock("ulric")
+RECIPE("bonemeal-salt"):remove_unlock("ulric"):set_fields {hidden = true}
 RECIPE("fertilizer-2"):remove_unlock("basic-electronics")
 RECIPE("molten-stainless-steel"):add_ingredient {type = "item", name = "cobalt-extract", amount = 1}
 RECIPE("full-molten-stainless-steel-3"):add_ingredient {type = "item", name = "cobalt-extract", amount = 1}


### PR DESCRIPTION
Resolves https://github.com/pyanodon/pybugreports/issues/1126

Original report was likely attempting to set filters with a recipe signal. With these recipes hidden, the only remaining signal with the plain bone meal icon is the item.