### PR TITLE
Remove print when opening caravan manager

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -1,4 +1,9 @@
 ---------------------------------------------------------------------------------------------------
+Version: 3.0.54
+Date: Hopefully more than a day from the previous release
+  Changes:
+    - Removed debug chat message when opening caravan manager
+---------------------------------------------------------------------------------------------------
 Version: 3.0.53
 Date: 2025-8-13
   Changes:

--- a/scripts/caravan/utils.lua
+++ b/scripts/caravan/utils.lua
@@ -162,7 +162,6 @@ local function get_fluidavan_inventory_tooltip(caravan_data)
 end
 
 function P.get_inventory_tooltip(caravan_data)
-    game.print(caravan_data.entity.name)
     if caravan_data.entity.name == "fluidavan" then
         return get_fluidavan_inventory_tooltip(caravan_data)
     end


### PR DESCRIPTION
Resolves pyanodon/pybugreports#1145