### PR TITLE
T.U.R.D. icon overlay refactor

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -5,6 +5,7 @@ Date: Hopefully more than a day from the previous release
     - Fixed bio-crane power usage when active.
     - Fixed speed of Wood Processing Units MK 2+ with sawblades TURD.
     - Fixed TURD buildings spilling on upgrade when they shouldn't.
+    - Fixed error in sprite loader with certain mod sets.
     - Updated RU locale (thanks, Astorin!).
     - Caravans: removed debug chat message when opening caravan manager.
     - Caravans: fixed item-count conditions on caravan interrupts being '0' when previously set.

--- a/info.json
+++ b/info.json
@@ -16,7 +16,7 @@
         "pypetroleumhandling >= 3.0.0",
         "pycoalprocessing >= 3.0.36",
         "? pyhightech >= 3.0.0",
-        "~ pypostprocessing >= 3.0.28",
+        "~ pypostprocessing >= 3.0.36",
         "! wret-beacon-rebalance-mod",
         "! BigBags",
         "! ResearchFog",

--- a/prototypes/buildings/crane.lua
+++ b/prototypes/buildings/crane.lua
@@ -102,8 +102,8 @@ RECIPE {
 for i = 1, 4 do
 	local name = "crane-mk0" .. i
 	local icon = {
-	  {icon = "__pyalienlifegraphics3__/graphics/entity/crane/inserter-icon-greyscale.png", tint = py.tints[i]},
-	  {icon = "__pyalienlifegraphics__/graphics/icons/meat.png", scale = .5, shift = {16, 16}}
+	  {icon = "__pyalienlifegraphics3__/graphics/entity/crane/inserter-icon-greyscale.png", tint = py.tints[i], icon_size = 64},
+	  {icon = "__pyalienlifegraphics__/graphics/icons/meat.png", scale = .5, shift = {16, 16}, icon_size = 32}
   }
 
 	ITEM {

--- a/prototypes/turd.lua
+++ b/prototypes/turd.lua
@@ -205,40 +205,41 @@ local function build_tech_upgrade(tech_upgrade)
             elseif effect.type == "recipe-replacement" and data.raw.recipe[effect.new] then
                 py.add_to_description("recipe", data.raw.recipe[effect.new], {"turd.font", {"turd.recipe-replacement"}})
                 local recipe = data.raw.recipe[effect.new]
-                if recipe then
-                    local main_product = recipe.main_product or #recipe.results == 1 and recipe.results[1].name
-                    main_product = data.raw.item[main_product] or data.raw.module[main_product] or data.raw.fluid[main_product] or data.raw["spider-vehicle"][main_product] or data.raw.unit[main_product] or data.raw.car[main_product] or data.raw.capsule[main_product] or data.raw.tool[main_product]
-                    recipe.icons = recipe.icon and {{
-                        icon = recipe.icon,
-                        icon_size = recipe.icon_size
-                    }} or (recipe.icons and table.deepcopy(recipe.icons)) or main_product.icon and {{
-                        icon = main_product.icon,
-                        icon_size = main_product.icon_size
-                    }} or (main_product.icons and table.deepcopy(main_product.icons))
-                    recipe.icons[#recipe.icons+1] = {
+                local icon_base = recipe and recipe:get_icons()
+                if icon_base then
+                    -- Combine the base icon with our overlay
+                    recipe.icons = util.combine_icons(icon_base, {{
                         icon = "__pycoalprocessinggraphics__/graphics/icons/gui/turd.png",
-                        shift = {14, -6},
-                        scale = 0.35,
-                        floating = true
-                    }
+                        shift = {10, -10},
+                        scale = 0.35
+                    }}, {}, 40)
+                    -- this property isn't transferred by combine_icons and allows the overlay to sit outside the render area of the base icon
+                    recipe.icons[#recipe.icons].floating = true
                     recipe.icon = nil
                     recipe.icon_size = nil
                 end
             elseif effect.type == "machine-replacement" then
-                local machine = data.raw["assembling-machine"][effect.new] or data.raw.furnace[effect.new] or data.raw["burner-generator"][effect.new]
+                local machine
+                for _, prototype_category in py.iter_prototype_categories("entity") do
+                    machine = prototype_category[effect.new]
+                    if machine then break end
+                end
+                -- can be nil if all categories are somehow missing it
                 if machine then
-                    machine.icons = machine.icons or {{
+                    local icon_base = machine.icons or {{
                         icon = machine.icon,
                         icon_size = machine.icon_size
                     }}
-                    machine.icons[#machine.icons + 1] = {
+                    machine.icons = util.combine_icons(icon_base, {{
                         icon = "__pycoalprocessinggraphics__/graphics/icons/gui/turd.png",
-                        shift = {14, -6},
-                        scale = 0.35,
-                        floating = true
-                    }
+                        shift = {10, -10},
+                        scale = 0.35
+                    }}, {}, 40)
+                    machine.icons[#machine.icons].floating = true
                     machine.icon = nil
                     machine.icon_size = nil
+                else
+                    error(string.format("No entity found with name %s", effect.new))
                 end
             end
         end


### PR DESCRIPTION
No longer limited to specific type lists, also solves the scaling issue when starting the game (below):
```
   4.332 Error ParallelSpriteLoader.cpp:67: Parallel sprite loading failed, falling back to normal sprite loading. The given sprite rectangle (left_top=0x0, right_bottom=64x64) is outside the actual sprite size (left_top=0x0, right_bottom=40x40).
If this is being used as an icon you may need to define the icon_size property.
See the log file for more information.: __pycoalprocessinggraphics__/graphics/icons/gui/turd.png
         RAM: 42015/63092 MB, page: 72232/90740 MB, virtual: 6449/134217727 MB, extended virtual: 0 MB
```