### PR TITLE
Caravans: fix comparisons with `0` failing

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -15,6 +15,7 @@ Date: Hopefully more than a day from the previous release
     - Caravans: fixed crash picking up caravans as a non-character.
     - Caravans: fixed crash in on_player_main_inventory_changed.
     - Caravans: fixed crash migrating now-removed signals.
+    - Caravans: fixed conditions failing if comparing with 0
 ---------------------------------------------------------------------------------------------------
 Version: 3.0.53
 Date: 2025-8-13

--- a/scripts/caravan/impl/actions.lua
+++ b/scripts/caravan/impl/actions.lua
@@ -375,7 +375,7 @@ function P.circuit_condition_static(caravan_data, schedule, action)
 
     local right = action.circuit_condition_right
     local left = action.item_count
-    if not right or not left then return false end
+    if not right or left == nil then return false end
 
     if not outpost or not outpost.valid then
         left = 0
@@ -403,7 +403,7 @@ function P.food_count(caravan_data, schedule, action)
     local item = action.elem_value
 
     local right = action.item_count
-    if not right then return false end
+    if right == nil then return false end
 
     local left = caravan_data.fuel_inventory.get_item_count(item)
 
@@ -427,7 +427,7 @@ function P.caravan_item_count(caravan_data, schedule, action)
     local item = action.elem_value
 
     local right = action.item_count
-    if not right then return false end
+    if right == nil then return false end
 
     local left = caravan_data.inventory.get_item_count(item)
 
@@ -455,7 +455,7 @@ function P.target_item_count(caravan_data, schedule, action)
     local item = action.elem_value
 
     local right = action.item_count
-    if not right then return false end
+    if right == nil then return false end
 
     local outpost_inventory = get_outpost_inventory(outpost)
     if not outpost_inventory then return false end
@@ -483,7 +483,7 @@ function P.outpost_item_count(caravan_data, schedule, action)
     local item = action.elem_value
 
     local right = action.item_count
-    if not right then return false end
+    if right == nil then return false end
 
     local outpost_inventory = get_outpost_inventory(outpost)
     if not outpost_inventory then return false end
@@ -631,7 +631,7 @@ function P.target_fluid_count(caravan_data, schedule, action)
     local fluid_name = action.elem_value
 
     local right = action.item_count or 0
-    if not right then return false end
+    if right == nil then return false end
 
     local left
     local outpost_fluid = outpost.get_fluid(1)


### PR DESCRIPTION
`if not 0` will always trigger, lua moment