### PR TITLE
Check for existing caravan_gui before adding

### DIFF
--- a/scripts/caravan/gui/main_frame.lua
+++ b/scripts/caravan/gui/main_frame.lua
@@ -24,6 +24,11 @@ function P.build_title_bar_flow(parent, caravan_data)
 end
 
 function P.build_main_frame(parent, name, caravan_data)
+    local existing = parent["caravan_gui"]
+    if existing then
+        existing.destroy()
+    end
+ 
     local main_frame = parent.add {type = "frame", direction = "vertical", name = name, tags = {unit_number = caravan_data.unit_number}}
     if caravan_data.entity.name:find("^fluidavan") then
         main_frame.style.natural_height = 910


### PR DESCRIPTION
resolves:

Error while running event pyalienlife::open-gui (ID 224)
Gui element with name caravan_gui already present in the parent element.

<img width="1018" height="742" alt="image" src="https://github.com/user-attachments/assets/e3e377ac-9cd8-4777-a85e-65663eb9a949" />
