### PR TITLE
Make vatbrain migration work for older saves

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -4,7 +4,8 @@ Date: ?
   Changes:
     - Made seaweed float (around)
     - When selecting view on map with an outpost selected, the map view now centers on the outpost rather than the caravan. Resolves https://github.com/pyanodon/pybugreports/issues/1170
-    - Reduce actual vatbrain radius by one tile to the east and south to match visible vatbrain radius. See https://github.com/pyanodon/pybugreports/issues/1062
+    - Reduce actual vatbrain radius by one tile match visible vatbrain radius. See https://github.com/pyanodon/pybugreports/issues/1062
+    - Fix actual vatbrain radius being offset by one tile to the east and south. See https://github.com/pyanodon/pybugreports/issues/1062
     - Caravans: when selecting view on map with an outpost selected, the map view now centers on the outpost rather than the caravan. Resolves https://github.com/pyanodon/pybugreports/issues/1170
     - Caravans: fixed that ESC/E wouldn't close a caravan menu when opened from a caravan outpost.
     - Caravans: fixed scroll pane overlapping buttons in outpost's caravan view

--- a/migrations/3.0.57.lua
+++ b/migrations/3.0.57.lua
@@ -5,7 +5,6 @@ local SECONDS = 60
 local migrated_storage = {}
 
 local function search_area(surface, position, square_width)
-    if storage.skip_vatbrain_check then return {} end
     local radius = square_width / 2
     local top_left = {position.x - radius, position.y - radius}
     local bottom_right = {position.x + radius, position.y + radius}
@@ -25,7 +24,7 @@ for _, unit_number in pairs(storage.vatbrains) do
         local surface = vatbrain.surface
         -- Store the old beacon list for reference below
         local old_receivers = {}
-        for _, recipient in pairs(search_area(surface, beacon.position, 25)) do
+        for _, recipient in pairs(search_area(surface, beacon.position, storage.skip_vatbrain_check and 23 or 25)) do
             if recipient.valid then
                 old_receivers[recipient.unit_number] = recipient
             end


### PR DESCRIPTION
Only checks the moved radius instead of a different radius.