### PR TITLE
Caravans: make restoring UI location save initial position

### DIFF
--- a/scripts/caravan/event-handlers/interrupts.lua
+++ b/scripts/caravan/event-handlers/interrupts.lua
@@ -37,7 +37,7 @@ local function on_add_interrupt_confirmed(event)
     end
     CaravanScheduleGui.update_schedule_pane(player)
     local edit_interrupt_gui = EditInterruptGui.build(player.gui.screen, storage.interrupts[name])
-    edit_interrupt_gui.location = window_location
+    CaravanUtils.restore_gui_location(edit_interrupt_gui, window_location)
 end
 
 local function on_edit_interrupt_confirmed(event)

--- a/scripts/caravan/utils.lua
+++ b/scripts/caravan/utils.lua
@@ -296,6 +296,7 @@ function P.restore_gui_location(element, fallback_location)
     local location = (storage.gui_locations[element.player_index] or {})[element.name] or fallback_location
     if location then
         element.location = location
+        P.store_gui_location(element)
     end
 end
 


### PR DESCRIPTION
if the user has no position saved, save the first position of the window until the user makes changes