### PR TITLE
Buff fluid mining drills

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -6,6 +6,7 @@ Date: ?
     - When selecting view on map with an outpost selected, the map view now centers on the outpost rather than the caravan. Resolves https://github.com/pyanodon/pybugreports/issues/1170
     - Reduce actual vatbrain radius by one tile match visible vatbrain radius. See https://github.com/pyanodon/pybugreports/issues/1062
     - Fix actual vatbrain radius being offset by one tile to the east and south. See https://github.com/pyanodon/pybugreports/issues/1062
+    - Buff fluid mining drills to have larger mining area and lower resource drain at higher tiers
     - Caravans: when selecting view on map with an outpost selected, the map view now centers on the outpost rather than the caravan. Resolves https://github.com/pyanodon/pybugreports/issues/1170
     - Caravans: fixed that ESC/E wouldn't close a caravan menu when opened from a caravan outpost.
     - Caravans: fixed scroll pane overlapping buttons in outpost's caravan view

--- a/prototypes/buildings/fluid-drill-mk02.lua
+++ b/prototypes/buildings/fluid-drill-mk02.lua
@@ -65,7 +65,8 @@ ENTITY {
         usage_priority = "secondary-input"
     },
     energy_usage = "900kW",
-    resource_searching_radius = 3.49,
+    resource_searching_radius = 4.49,
+    resource_drain_rate_percent = 50,
     vector_to_place_result = {0, -2.65},
     radius_visualisation_picture = {
         filename = "__base__/graphics/entity/electric-mining-drill/electric-mining-drill-radius-visualization.png",

--- a/prototypes/buildings/fluid-drill-mk03.lua
+++ b/prototypes/buildings/fluid-drill-mk03.lua
@@ -64,7 +64,8 @@ ENTITY {
         usage_priority = "secondary-input"
     },
     energy_usage = "1200kW",
-    resource_searching_radius = 3.49,
+    resource_searching_radius = 5.49,
+    resource_drain_rate_percent = 25,
     vector_to_place_result = {0, -2.65},
     radius_visualisation_picture = {
         filename = "__base__/graphics/entity/electric-mining-drill/electric-mining-drill-radius-visualization.png",

--- a/prototypes/buildings/fluid-drill-mk04.lua
+++ b/prototypes/buildings/fluid-drill-mk04.lua
@@ -65,7 +65,8 @@ ENTITY {
         usage_priority = "secondary-input"
     },
     energy_usage = "1400kW",
-    resource_searching_radius = 3.49,
+    resource_searching_radius = 6.49,
+    resource_drain_rate_percent = 12.5,
     vector_to_place_result = {0, -2.65},
     radius_visualisation_picture = {
         filename = "__base__/graphics/entity/electric-mining-drill/electric-mining-drill-radius-visualization.png",


### PR DESCRIPTION
What it says on the tin - larger mining area and lower resource drain
- mk1: 7x7 area, 100% drain
- mk2: 9x9 area, 50% drain
- mk3: 11x11 area, 25% drain
- mk4: 13x13, 12.5% drain

Together, this and https://github.com/pyanodon/pyalternativeenergy/pull/124 resolve https://github.com/pyanodon/pybugreports/issues/1182