### PR TITLE
caravans: add hint for re-assigning interrupt target

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -11,6 +11,7 @@ Date: ???
     - Caravans: fixed fuel being deleted when right-clicked with a different fuel in cursor
     - Caravans: fixed being able to put anything in fluid caravan fuel slots
     - Caravans: restores controller type and camera position when using/dropping the carrot
+    - Caravans: add hint for re-assigning interrupt target via right-click
 ---------------------------------------------------------------------------------------------------
 Version: 3.0.57
 Date: 2025-08-23

--- a/scripts/caravan/gui/edit_interrupt.lua
+++ b/scripts/caravan/gui/edit_interrupt.lua
@@ -140,6 +140,7 @@ function P.build_action_list(parent, schedule_id)
 end
 
 function P.build_target_destination_frame(parent, schedule_id)
+    local schedule = storage.edited_interrupt.schedule[schedule_id]
     local tags = {schedule_id = schedule_id, action_list_type = Caravan.action_list_types.interrupt_targets}
 
     local frame = parent.add {type = "frame", style = "train_schedule_station_frame"}
@@ -148,8 +149,14 @@ function P.build_target_destination_frame(parent, schedule_id)
     local flow = frame.add {type = "flow", direction = "horizontal"}
     flow.style.vertical_align = "center"
 
-    local label_style, label_tooltip = label_info(storage.edited_interrupt, schedule_id)
-    local destination_label = flow.add {type = "label", name = "py_edit_interrupt_target_name", style = label_style, caption = storage.edited_interrupt.schedule[schedule_id].localised_name, tooltip = label_tooltip, tags = tags}
+    local entity = schedule.entity
+    local caption
+    if entity and entity.valid then
+        caption = schedule.localised_name
+    else
+        caption = {"caravan-gui.not-specified"}
+    end
+    local destination_label = flow.add {type = "label", name = "py_edit_interrupt_target_name", style = "clickable_squashable_label", caption = caption, tooltip = {"caravan-gui.reassign-hint", caption}, tags = tags}
     destination_label.style.left_padding = 5
     destination_label.style.horizontally_squashable = true
 


### PR DESCRIPTION
it was there before but even I didn't know that without testing