### PR TITLE
caravans: fix missing padding in interrupt target list

### DIFF
--- a/scripts/caravan/gui/action_widgets/number_selection.lua
+++ b/scripts/caravan/gui/action_widgets/number_selection.lua
@@ -107,6 +107,7 @@ end
 
 function P.build_time_selection_button(parent, action, tags)
     tags.elem_type = "time"
+    parent.add {type = "empty-widget"}.style.horizontally_stretchable = true
     local btn = parent.add {type = "button", name = prefix .. "_button", style = "train_schedule_condition_time_selection_button", tags = tags}
     btn.style.width = 44
     btn.style.right_padding = 0

--- a/scripts/caravan/gui/actions.lua
+++ b/scripts/caravan/gui/actions.lua
@@ -72,9 +72,10 @@ function P.build_action_flow(parent, caravan_data, action, tags)
         else
             label.caption = {locale_key, {"caravan-gui.not-specified"}}
         end
+    else
+        flow.add {type = "empty-widget"}.style.horizontally_stretchable = true
     end
 
-    flow.add {type = "empty-widget"}.style.horizontally_stretchable = true
     if Utils.contains(possibly_blocking_actions, action.type) then
         flow.add {type = "checkbox", name = "py_caravan_action_blocking_checkbox", state = not action.async, tooltip = {"caravan-gui.wait"}, tags = tags}
     end


### PR DESCRIPTION
wasn't shipped in any update so no changelog for this one