### PR TITLE
Caravan/fluid outpost count

### DIFF
--- a/locale/en/caravan.cfg
+++ b/locale/en/caravan.cfg
@@ -104,6 +104,8 @@ at-outpost2=at __1__
 not-at-outpost2=not at __1__
 outpost-item-count=Outpost item count
 outpost-item-count2=__1__ item count
+outpost-fluid-count=Outpost fluid count
+outpost-fluid-count2=__1__ fluid count
 
 [caravan-actions-short]
 load-caravan=Load caravan until
@@ -112,6 +114,7 @@ load-target=Load target until
 unload-target=Unload target until
 circuit-condition-static=Circuit condition
 outpost-item-count=[__1__, __2__] item count
+outpost-fluid-count=[__1__, __2__] fluid count
 
 [item-name]
 caravan-control=Caravan control

--- a/scripts/caravan/caravan-prototypes.lua
+++ b/scripts/caravan/caravan-prototypes.lua
@@ -219,7 +219,8 @@ Caravan.valid_actions = {
         "circuit-condition-static",
         "at-outpost",
         "not-at-outpost",
-        "outpost-item-count"
+        "outpost-item-count",
+        "outpost-fluid-count"
     }
 }
 Caravan.valid_actions.nukavan = table.deepcopy(Caravan.valid_actions.caravan)
@@ -237,6 +238,7 @@ Caravan.actions_with_item_count = table.invert{
     "caravan-item-count",
     "target-item-count",
     "outpost-item-count",
+    "outpost-fluid-count",
     "caravan-fluid-count",
     "target-fluid-count",
 }

--- a/scripts/caravan/event-handlers/destination.lua
+++ b/scripts/caravan/event-handlers/destination.lua
@@ -132,6 +132,8 @@ gui_events[defines.events.on_gui_selection_state_changed]["py_caravan_destinatio
         localised_name = {"caravan-actions.not-at-outpost2", {"caravan-gui.not-specified"}}
     elseif type == "outpost-item-count" then
         localised_name = {"caravan-actions.outpost-item-count2", {"caravan-gui.not-specified"}}
+    elseif type == "outpost-fluid-count" then
+        localised_name = {"caravan-actions.outpost-fluid-count2", {"caravan-gui.not-specified"}}
     end
     table.insert(caravan_data.schedule[schedule_id].actions, CaravanUtils.ensure_item_count{type = type, localised_name = localised_name})
 

--- a/scripts/caravan/event-handlers/interrupts.lua
+++ b/scripts/caravan/event-handlers/interrupts.lua
@@ -177,6 +177,8 @@ gui_events[defines.events.on_gui_selection_state_changed]["py_edit_interrupt_add
         localised_name = {"caravan-actions.not-at-outpost2", {"caravan-gui.not-specified"}}
     elseif type == "outpost-item-count" then
         localised_name = {"caravan-actions.outpost-item-count2", {"caravan-gui.not-specified"}}
+    elseif type == "outpost-fluid-count" then
+        localised_name = {"caravan-actions.outpost-fluid-count2", {"caravan-gui.not-specified"}}
     end
     table.insert(storage.edited_interrupt.conditions, CaravanUtils.ensure_item_count{type = type, localised_name = localised_name})
     if #storage.edited_interrupt.conditions > 1 then
@@ -206,6 +208,8 @@ gui_events[defines.events.on_gui_selection_state_changed]["py_edit_interrupt_tar
         localised_name = {"caravan-actions.not-at-outpost2", {"caravan-gui.not-specified"}}
     elseif type == "outpost-item-count" then
         localised_name = {"caravan-actions.outpost-item-count2", {"caravan-gui.not-specified"}}
+    elseif type == "outpost-fluid-count" then
+        localised_name = {"caravan-actions.outpost-fluid-count2", {"caravan-gui.not-specified"}}
     end
     table.insert(schedule.actions, CaravanUtils.ensure_item_count{type = type, localised_name = localised_name})
 

--- a/scripts/caravan/gui/actions.lua
+++ b/scripts/caravan/gui/actions.lua
@@ -32,46 +32,13 @@ function P.build_action_flow(parent, caravan_data, action, tags)
     local label = flow.add {type = "label", style = "squashable_label_with_left_padding", caption = action.localised_name}
     if action.type == "time-passed" then
         number_selection.build_time_selection_button(flow, action, tags)
-    elseif action.type == "circuit-condition" then
-        comparator.build_circuit_comparator_widgets(flow, action, tags)
-    elseif action.type == "circuit-condition-static" then
-        comparator.build_static_comparator_widgets(flow, action, tags, "signal")
     elseif Utils.contains({"load-caravan", "unload-caravan", "load-target", "unload-target"}, action.type) then
         -- don't know why we restrict comparison here, shouldn't it be a regular dropdown?
         comparator.build_static_comparator_widgets(flow, action, tags, "item", nil, "=")
-        -- these are interrupt-only
-    elseif Utils.contains({"food-count", "caravan-item-count", "target-item-count"}, action.type) then
-        local filters
-        if action.type == "food-count" then
-            filters = {{filter = "name", name = Caravan.foods.all}}
-        end
-        comparator.build_static_comparator_widgets(flow, action, tags, "item", filters)
-    elseif action.type == "outpost-item-count" then
-        flow.add {type = "sprite-button", name = "py_caravan_action_add_outpost", tags = tags, index = 1, style = "train_schedule_action_button", sprite = "utility/rename_icon"}
-
-        local locale_key = "caravan-actions." .. action.type .. "2"
-        local entity = action.entity
-
-        if entity and entity.valid then
-            label.caption = {locale_key, {"caravan-gui.entity-position", entity.localised_name, entity.position.x, entity.position.y}}
-        else
-            label.caption = {locale_key, {"caravan-gui.not-specified"}}
-        end
-        comparator.build_static_comparator_widgets(flow, action, tags, "item", filters)
     elseif action.type == "store-specific-food" then
         local filters = {{filter = "name", name = Caravan.foods.all}}
 
         comparator.build_static_comparator_widgets(flow, action, tags, "item", filters, "≥")
-    elseif Utils.contains({"at-outpost", "not-at-outpost"}, action.type) then
-        flow.add {type = "sprite-button", name = "py_caravan_action_add_outpost", tags = tags, index = 1, style = "train_schedule_action_button", sprite = "utility/rename_icon"}
-
-        local locale_key = "caravan-actions." .. action.type .. "2"
-        local entity = action.entity
-        if entity and entity.valid then
-            label.caption = {locale_key, {"caravan-gui.entity-position", entity.localised_name, entity.position.x, entity.position.y}}
-        else
-            label.caption = {locale_key, {"caravan-gui.not-specified"}}
-        end
     else
         flow.add {type = "empty-widget"}.style.horizontally_stretchable = true
     end

--- a/scripts/caravan/gui/interrupt_conditions.lua
+++ b/scripts/caravan/gui/interrupt_conditions.lua
@@ -20,18 +20,19 @@ function P.build_condition_flow(parent, condition, tags)
         end
         flow.add {type = "label", name = "py_edit_interrupt_condition_select_outpost_button", tags = tags, index = 1, style = "clickable_squashable_label", caption = caption, tooltip = {"caravan-gui.reassign-hint", caption}}.style.left_padding = 4
         flow.add {type = "empty-widget"}.style.horizontally_stretchable = true
-    elseif condition.type == "outpost-item-count" then
+    elseif Utils.contains({"outpost-item-count", "outpost-fluid-count"}, condition.type) then
         local locale_key = "caravan-actions." .. condition.type .. "2"
         local entity = condition.entity
         local caption
 
         if entity and entity.valid then
-            caption = {"caravan-actions-short.outpost-item-count", entity.position.x, entity.position.y}
+            caption = {"caravan-actions-short." .. condition.type, entity.position.x, entity.position.y}
         else
             caption = {locale_key, {"caravan-gui.not-specified"}}
         end
         flow.add {type = "label", name = "py_edit_interrupt_condition_select_outpost_button", tags = tags, index = 1, style = "clickable_squashable_label", caption = caption, tooltip = {"caravan-gui.reassign-hint", caption}}.style.left_padding = 4
-        comparator.build_static_comparator_widgets(flow, condition, tags, "item")
+        local elem_type = condition.type == "outpost-item-count" and "item" or "fluid"
+        comparator.build_static_comparator_widgets(flow, condition, tags, elem_type)
     else
         flow.add {type = "label", style = "squashable_label_with_left_padding", caption = condition.localised_name}
         if condition.type == "circuit-condition" then

--- a/scripts/caravan/impl/actions.lua
+++ b/scripts/caravan/impl/actions.lua
@@ -506,6 +506,33 @@ function P.outpost_item_count(caravan_data, schedule, action)
     end
 end
 
+function P.outpost_fluid_count(caravan_data, schedule, action)
+    local outpost = action.entity
+    if not outpost or not outpost.valid or outpost.name ~= "outpost-fluid" then return false end
+
+    local fluid = action.elem_value
+
+    local right = action.item_count
+    if right == nil then return false end
+
+    local left = outpost.get_fluid_count(fluid)
+
+    local operator = action.operator or 3
+    if operator == 1 then
+        return left > right
+    elseif operator == 2 then
+        return left < right
+    elseif operator == 3 then
+        return left == right
+    elseif operator == 4 then
+        return left >= right
+    elseif operator == 5 then
+        return left <= right
+    elseif operator == 6 then
+        return left ~= right
+    end
+end
+
 function P.is_inventory_full(caravan_data, schedule, action)
     return (caravan_data.inventory and caravan_data.inventory.is_full()) or P.is_tank_full(caravan_data, schedule, action)
 end
@@ -676,6 +703,7 @@ Caravan.actions = {
     ["caravan-item-count"] = P.caravan_item_count,
     ["target-item-count"] = P.target_item_count,
     ["outpost-item-count"] = P.outpost_item_count,
+    ["outpost-fluid-count"] = P.outpost_fluid_count,
     ["is-inventory-full"] = P.is_inventory_full,
     ["is-inventory-empty"] = P.is_inventory_empty,
     ["at-outpost"] = P.at_outpost,


### PR DESCRIPTION
Add outpost-fluid-count interrupt condition.

Evaluating the condition against a non fluid outpost will always return `false`.