### PR TITLE
Fix fluid output postions of tuuphra-plantation-mk01

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -29,6 +29,7 @@ Date: ???
     - Phagnot food recipe unlocked via Healthy rumination TURD now accepts productivity
     - Added Dutch locale
     - Fixed that building a T.U.R.D. building also placed an item on the ground inside the hitbox
+    - Change fluid output positions of tuuphra-platation-mk02/mk03/mk04 to be the same position as mk01
 ---------------------------------------------------------------------------------------------------
 Version: 3.0.57
 Date: 2025-08-23

--- a/prototypes/buildings/tuuphra-plantation-mk02.lua
+++ b/prototypes/buildings/tuuphra-plantation-mk02.lua
@@ -197,14 +197,14 @@ ENTITY {
             pipe_covers = py.pipe_covers(false, true, true, true),
             pipe_picture = py.pipe_pictures("assembling-machine-3", nil, {0.0, -0.88}, nil, nil),
             volume = 100,
-            pipe_connections = {{flow_direction = "output", position = {2.0, 4.0}, direction = defines.direction.south}}
+            pipe_connections = {{flow_direction = "output", position = {3.0, 4.0}, direction = defines.direction.south}}
         },
         {
             production_type = "output",
             pipe_covers = py.pipe_covers(false, true, true, true),
             pipe_picture = py.pipe_pictures("assembling-machine-3", nil, {0.0, -0.88}, nil, nil),
             volume = 100,
-            pipe_connections = {{flow_direction = "output", position = {-2.0, 4.0}, direction = defines.direction.south}}
+            pipe_connections = {{flow_direction = "output", position = {-3.0, 4.0}, direction = defines.direction.south}}
         },
     },
     impact_category = "metal-large",

--- a/prototypes/buildings/tuuphra-plantation-mk03.lua
+++ b/prototypes/buildings/tuuphra-plantation-mk03.lua
@@ -196,14 +196,14 @@ ENTITY {
             pipe_covers = py.pipe_covers(false, true, true, true),
             pipe_picture = py.pipe_pictures("assembling-machine-3", nil, {0.0, -0.88}, nil, nil),
             volume = 100,
-            pipe_connections = {{flow_direction = "output", position = {2.0, 4.0}, direction = defines.direction.south}}
+            pipe_connections = {{flow_direction = "output", position = {3.0, 4.0}, direction = defines.direction.south}}
         },
         {
             production_type = "output",
             pipe_covers = py.pipe_covers(false, true, true, true),
             pipe_picture = py.pipe_pictures("assembling-machine-3", nil, {0.0, -0.88}, nil, nil),
             volume = 100,
-            pipe_connections = {{flow_direction = "output", position = {-2.0, 4.0}, direction = defines.direction.south}}
+            pipe_connections = {{flow_direction = "output", position = {-3.0, 4.0}, direction = defines.direction.south}}
         },
     },
     impact_category = "metal-large",

--- a/prototypes/buildings/tuuphra-plantation-mk04.lua
+++ b/prototypes/buildings/tuuphra-plantation-mk04.lua
@@ -195,14 +195,14 @@ ENTITY {
             pipe_covers = py.pipe_covers(false, true, true, true),
             pipe_picture = py.pipe_pictures("assembling-machine-3", nil, {0.0, -0.88}, nil, nil),
             volume = 100,
-            pipe_connections = {{flow_direction = "output", position = {2.0, 4.0}, direction = defines.direction.south}}
+            pipe_connections = {{flow_direction = "output", position = {3.0, 4.0}, direction = defines.direction.south}}
         },
         {
             production_type = "output",
             pipe_covers = py.pipe_covers(false, true, true, true),
             pipe_picture = py.pipe_pictures("assembling-machine-3", nil, {0.0, -0.88}, nil, nil),
             volume = 100,
-            pipe_connections = {{flow_direction = "output", position = {-2.0, 4.0}, direction = defines.direction.south}}
+            pipe_connections = {{flow_direction = "output", position = {-3.0, 4.0}, direction = defines.direction.south}}
         },
     },
     impact_category = "metal-large",


### PR DESCRIPTION
Currently the Tuuphra plantation mk01 has some of the fluid outputs in slightly different places than the mk02, mk03 and mk04.

* Changes the fluid outputs of the mk01 to be in the same positions as the other tiers.


**Pull request notes**
This will unfortunately break existing mk01 setups :(
Another way to solve this would be to change mk02..mk04 fluid outputs to the mk01 layout;
I personally prefer the mk01 change though, as it changes less overall and thus breaks fewer setups -
At least that is what i think ;b