### PR TITLE
Caravan respect "Enable Warning Icon Blinking" in global.lua

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -2,6 +2,7 @@
 Version: 3.0.60
 Date: ????
   Changes:
+    - Fixed Caravans not respecting "Enable Warning Icon Blinking" setting
     - Fixed some techs having a too-fast cycle time
     - Fixed all techs added by "enable all feature flags" not being seen by autotech.
 ---------------------------------------------------------------------------------------------------

--- a/scripts/caravan/event-handlers/global.lua
+++ b/scripts/caravan/event-handlers/global.lua
@@ -337,7 +337,7 @@ py.on_event(defines.events.on_ai_command_completed, function(event)
     end
 end)
 
-py.register_on_nth_tick(61, "update-caravans", "pyal", function()
+py.register_on_nth_tick(60, "update-caravans", "pyal", function()
     local guis_to_update = {}
 
     if not storage.caravan_queue then
@@ -360,7 +360,7 @@ py.register_on_nth_tick(61, "update-caravans", "pyal", function()
 
         if needs_fuel then
             CaravanImpl.add_alert(entity, Caravan.alerts.no_fuel)
-            py.draw_error_sprite(entity, "virtual-signal.py-no-food", 61, 61/2)
+            py.draw_error_sprite(entity, "virtual-signal.py-no-food", 62, 31)
             goto continue
         end
 

--- a/scripts/caravan/event-handlers/global.lua
+++ b/scripts/caravan/event-handlers/global.lua
@@ -360,7 +360,7 @@ py.register_on_nth_tick(60, "update-caravans", "pyal", function()
 
         if needs_fuel then
             CaravanImpl.add_alert(entity, Caravan.alerts.no_fuel)
-            py.draw_error_sprite(entity, "virtual-signal.py-no-food", 30)
+            py.draw_error_sprite(entity, "virtual-signal.py-no-food", time_to_live, blink_interval)
             goto continue
         end
 

--- a/scripts/caravan/event-handlers/global.lua
+++ b/scripts/caravan/event-handlers/global.lua
@@ -337,7 +337,7 @@ py.on_event(defines.events.on_ai_command_completed, function(event)
     end
 end)
 
-py.register_on_nth_tick(60, "update-caravans", "pyal", function()
+py.register_on_nth_tick(61, "update-caravans", "pyal", function()
     local guis_to_update = {}
 
     if not storage.caravan_queue then
@@ -360,7 +360,7 @@ py.register_on_nth_tick(60, "update-caravans", "pyal", function()
 
         if needs_fuel then
             CaravanImpl.add_alert(entity, Caravan.alerts.no_fuel)
-            py.draw_error_sprite(entity, "virtual-signal.py-no-food", time_to_live, blink_interval)
+            py.draw_error_sprite(entity, "virtual-signal.py-no-food", 61, 61/2)
             goto continue
         end
 


### PR DESCRIPTION
Extended fix to include caravans https://github.com/pyanodon/pybugreports/issues/1090