### PR TITLE
Hide some disabled recipes from factoriopedia

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -18,6 +18,7 @@ Date: ????
     - Fixed an issue with simik den localization. Fixes https://github.com/pyanodon/pybugreports/issues/1217
     - Added keyboard shortcuts for quickly opening the T.U.R.D. codex page and the Caravan manager.
     - Enhanced caravan number input to handle MathExp and large numbers better.
+    - Hide some unused urea and lard recipes from factoriopedia
 ---------------------------------------------------------------------------------------------------
 Version: 3.0.59
 Date: 2025-09-15

--- a/prototypes/updates/pyhightech-updates.lua
+++ b/prototypes/updates/pyhightech-updates.lua
@@ -437,7 +437,7 @@ ITEM("urea"):subgroup_order("py-alienlife-auog", "a")
 ITEM("mosfet"):subgroup_order("py-hightech-tier-2", "f")
 RECIPE("waste-water-urea"):subgroup_order("py-alienlife-recipes", "a"):remove_unlock("fluid-separation"):add_unlock("water-invertebrates-mk01")
 RECIPE("ammonia-urea"):subgroup_order("py-alienlife-recipes", "a"):remove_unlock("basic-electronics"):add_unlock("biotech-mk02")
-RECIPE("urea2"):remove_unlock("auog-2")
+RECIPE("urea2"):remove_unlock("auog-2"):set_fields {hidden = true}
 RECIPE("urea"):set_fields {enabled = false}
 RECIPE("mukmoux-fat2"):remove_unlock("advanced-circuit")
 RECIPE("mukmoux-fat3"):remove_unlock("advanced-circuit")

--- a/prototypes/updates/pyhightech-updates.lua
+++ b/prototypes/updates/pyhightech-updates.lua
@@ -439,8 +439,8 @@ RECIPE("waste-water-urea"):subgroup_order("py-alienlife-recipes", "a"):remove_un
 RECIPE("ammonia-urea"):subgroup_order("py-alienlife-recipes", "a"):remove_unlock("basic-electronics"):add_unlock("biotech-mk02")
 RECIPE("urea2"):remove_unlock("auog-2"):set_fields {hidden = true}
 RECIPE("urea"):set_fields {enabled = false}
-RECIPE("mukmoux-fat2"):remove_unlock("advanced-circuit")
-RECIPE("mukmoux-fat3"):remove_unlock("advanced-circuit")
+RECIPE("mukmoux-fat2"):remove_unlock("advanced-circuit"):set_fields {hidden = true}
+RECIPE("mukmoux-fat3"):remove_unlock("advanced-circuit"):set_fields {hidden = true}
 RECIPE("fertilizer"):remove_unlock("basic-electronics")
 RECIPE("advanced-circuit"):add_ingredient {type = "item", name = "battery", amount = 5}:add_ingredient {type = "item", name = "mosfet", amount = 5}
 RECIPE("processing-unit"):add_ingredient {type = "item", name = "mosfet", amount = 10}:add_ingredient {type = "item", name = "neuromorphic-chip", amount = 1}

--- a/prototypes/updates/pyrawores-updates.lua
+++ b/prototypes/updates/pyrawores-updates.lua
@@ -104,7 +104,7 @@ TECHNOLOGY("nexelit-mk03"):add_pack("military-science-pack")
 RECIPE("chemical-plant-mk01"):remove_unlock("filtration"):add_unlock("electric-energy-accumulators")
 RECIPE("compressor-mk01"):remove_unlock("nitrogen-mk02")
 
-RECIPE("mukmoux-fat-salt"):remove_unlock("mukmoux")
+RECIPE("mukmoux-fat-salt"):remove_unlock("mukmoux"):set_fields {hidden = true}
 RECIPE("bonemeal-salt"):remove_unlock("ulric"):set_fields {hidden = true}
 RECIPE("fertilizer-2"):remove_unlock("basic-electronics")
 RECIPE("molten-stainless-steel"):add_ingredient {type = "item", name = "cobalt-extract", amount = 1}


### PR DESCRIPTION
Hide `urea2`, `mukmoux-fat-salt`, `mukmoux-fat2` and `mukmoux-fat3`

I feel like it might just be simpler to make this part of `add_unlock` and `remove_unlock`, 