### PR TITLE
Changed adult xyhiphoe recipes to use deluxe fish food at tier 3+

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -1,4 +1,9 @@
 ---------------------------------------------------------------------------------------------------
+Version: 3.0.61
+Date: 2025-11-08
+  Changes:
+    - Changed xyhiphoe recipes to use deluxe fish food instead of regular fish food starting at tier 3. Resolves https://github.com/pyanodon/pybugreports/issues/1259
+---------------------------------------------------------------------------------------------------
 Version: 3.0.60
 Date: 2025-11-02
   Changes:

--- a/prototypes/recipes/xyhiphoe/recipes-xyhiphoe-raising.lua
+++ b/prototypes/recipes/xyhiphoe/recipes-xyhiphoe-raising.lua
@@ -40,7 +40,7 @@ py.autorecipes {
 			},
 			tech = "water-invertebrates-mk02"
 		},
-		--food 2
+		--fish egg
 		{
 			ingredients =
 			{
@@ -52,7 +52,7 @@ py.autorecipes {
 			},
 			tech = "water-invertebrates-mk03"
 		},
-		--food 2 blood-meal
+		--food 2 fawogae
 		{
 			ingredients =
 			{
@@ -227,12 +227,14 @@ py.autorecipes {
 			crafting_speed = 130,
 			tech = "water-invertebrates-mk02"
 		},
-		--fish egg
+		--food 2 fish egg, no blood meal
 		{
 			ingredients =
 			{
 				{name = "blood-meal", remove_item = true},
 				{name = "saps",       remove_item = true},
+				{name = "fish-food-01", remove_item = true},
+				{name = "fish-food-02", amount = 1},
 				{name = "fish-egg",   amount = 15},
 
 			},
@@ -244,7 +246,7 @@ py.autorecipes {
 			crafting_speed = 110,
 			tech = "water-invertebrates-mk03"
 		},
-		--food 2 blood-meal
+		--blood-meal
 		{
 			ingredients =
 			{


### PR DESCRIPTION
https://github.com/pyanodon/pybugreports/issues/1259

This issue got me looking at the recipes. Based on the comments in the file, it seemed like deluxe fish food should be going in somewhere. Tier 3 makes sense, otherwise it is very cheap compared to tier 2 and tier 4. The issue implies all recipes above tier 1 should have blood meal, but I think the fish food change does enough for the progression.