### PR TITLE
navens_mk3 now use correct icon for breeding process

### DIFF
--- a/prototypes/recipes/navens/recipes-navens-modules.lua
+++ b/prototypes/recipes/navens/recipes-navens-modules.lua
@@ -135,6 +135,11 @@ RECIPE {
         {type = "item", name = "navens-mk03", amount = 4, probability = 0.375},
     },
     main_product = "navens-mk03",
+    icons =
+    {
+        {icon = "__pyalienlifegraphics__/graphics/icons/navens.png",         icon_size = 64},
+        {icon = "__pyalienlifegraphics__/graphics/icons/evolution-mk03.png", icon_size = 64, scale = 0.25, shift = {-7.5, -7.5}},
+    },
     icon_size = 64,
     subgroup = "py-alienlife-navens",
     order = "zb"


### PR DESCRIPTION
Fixes wrong icon being used for the navens mk3 breeding program as described in pyanodon/pybugreports#1311