### PR TITLE
Add Duplicate Interrupt button to Edit Interrupt window

### DIFF
--- a/locale/en/caravan.cfg
+++ b/locale/en/caravan.cfg
@@ -51,6 +51,7 @@ the-inventory-is-empty=The inventory is empty.
 add-interrupt-frame-title=Add interrupt
 edit-interrupt-frame-title=Edit interrupt
 save-interrupt=Save interrupt
+duplicate-interrupt=Duplicate interrupt
 delete-interrupt=Delete interrupt
 confirm-deletion=Are you sure?
 cancel-deletion=Cancel deletion

--- a/scripts/caravan/event-handlers/interrupts.lua
+++ b/scripts/caravan/event-handlers/interrupts.lua
@@ -342,7 +342,7 @@ gui_events[defines.events.on_gui_click]["py_duplicate_interrupt_button"] = funct
     local player = game.get_player(event.player_index)
     local edited_interrupt = storage.edited_interrupts[event.player_index]
 
-    -- edge case: need to check the rename textfield when 'Copy interrupt' is pressed instead of enter
+    -- edge case: need to check the rename textfield when 'Duplicate interrupt' is pressed instead of enter
     local textfield = event.element.parent.py_edit_interrupt_textfield
     if string.len(textfield.text) ~= 0 and textfield.text ~= edited_interrupt.name then
         edited_interrupt.name = textfield.text

--- a/scripts/caravan/event-handlers/interrupts.lua
+++ b/scripts/caravan/event-handlers/interrupts.lua
@@ -338,6 +338,39 @@ gui_events[defines.events.on_gui_click]["py_edit_interrupt_confirm_button"] = fu
     storage.edited_interrupts[event.player_index] = nil
 end
 
+gui_events[defines.events.on_gui_click]["py_duplicate_interrupt_button"] = function(event)
+    local player = game.get_player(event.player_index)
+    local edited_interrupt = storage.edited_interrupts[event.player_index]
+
+    -- edge case: need to check the rename textfield when 'Copy interrupt' is pressed instead of enter
+    local textfield = event.element.parent.py_edit_interrupt_textfield
+    if string.len(textfield.text) ~= 0 and textfield.text ~= edited_interrupt.name then
+        edited_interrupt.name = textfield.text
+    end
+
+    local interrupt_copy_name = edited_interrupt.name .. "*"
+    local increment = 2
+    while storage.interrupts[interrupt_copy_name] ~= nil do
+        interrupt_copy_name = edited_interrupt.name .. "* (" .. increment .. ")"
+        increment = increment + 1
+    end
+    
+    storage.interrupts[interrupt_copy_name] = table.deepcopy(edited_interrupt)
+    storage.interrupts[interrupt_copy_name].name = interrupt_copy_name
+
+    local unit_number = CaravanGui.get_gui(player).tags.unit_number
+    assert(unit_number)
+    local caravan_data = storage.caravans[unit_number]
+    table.insert(caravan_data.interrupts, interrupt_copy_name)
+    CaravanScheduleGui.update_schedule_pane(player)
+
+    if player.gui.screen.edit_interrupt_gui then
+        player.gui.screen.edit_interrupt_gui.destroy()
+        local edit_interrupt_gui = EditInterruptGui.build(player.gui.screen, storage.interrupts[interrupt_copy_name])
+        CaravanUtils.restore_gui_location(edit_interrupt_gui, window_location)
+    end
+end
+
 gui_events[defines.events.on_gui_click]["py_delete_interrupt_button"] = function(event)
     local element = event.element
     local removed_interrupt = element.tags.interrupt_name
@@ -366,6 +399,7 @@ gui_events[defines.events.on_gui_click]["py_delete_interrupt_button"] = function
         element.parent.py_delete_interrupt_cancel.visible = true
         element.parent.py_delete_interrupt_confirm.visible = true
         element.parent.py_interrupt_count_label.visible = false
+        element.parent.py_duplicate_interrupt_button.visible = false
     end
 end
 
@@ -375,6 +409,7 @@ gui_events[defines.events.on_gui_click]["py_delete_interrupt_cancel"] = function
     element.parent.py_interrupt_count_label.visible = true
     element.parent.py_delete_interrupt_cancel.visible = false
     element.parent.py_delete_interrupt_confirm.visible = false
+    element.parent.py_duplicate_interrupt_button.visible = true
 end
 
 gui_events[defines.events.on_gui_click]["py_edit_interrupt_condition_move_up_button"] = function(event)

--- a/scripts/caravan/event-handlers/interrupts.lua
+++ b/scripts/caravan/event-handlers/interrupts.lua
@@ -348,11 +348,9 @@ gui_events[defines.events.on_gui_click]["py_duplicate_interrupt_button"] = funct
         edited_interrupt.name = textfield.text
     end
 
-    local interrupt_copy_name = edited_interrupt.name .. "*"
-    local increment = 2
+    local interrupt_copy_name = edited_interrupt.name
     while storage.interrupts[interrupt_copy_name] ~= nil do
-        interrupt_copy_name = edited_interrupt.name .. "* (" .. increment .. ")"
-        increment = increment + 1
+        interrupt_copy_name = interrupt_copy_name .. "*"
     end
     
     storage.interrupts[interrupt_copy_name] = table.deepcopy(edited_interrupt)

--- a/scripts/caravan/event-handlers/interrupts.lua
+++ b/scripts/caravan/event-handlers/interrupts.lua
@@ -348,11 +348,19 @@ gui_events[defines.events.on_gui_click]["py_duplicate_interrupt_button"] = funct
         edited_interrupt.name = textfield.text
     end
 
-    local interrupt_copy_name = edited_interrupt.name
-    while storage.interrupts[interrupt_copy_name] ~= nil do
-        interrupt_copy_name = interrupt_copy_name .. "*"
+    local interrupt_copy_name = edited_interrupt.name .. " - Copy"
+
+    -- emulate the Windows duplicate name logic: if "<name> - Copy" is taken we append "(#n)"
+    if storage.interrupts[interrupt_copy_name] ~= nil then
+        for copy_num = 2, math.huge do
+            local new_copy_name = interrupt_copy_name .. string.format(" (%i)", copy_num)
+            if not storage.interrupts[new_copy_name] then
+                interrupt_copy_name = new_copy_name
+                break
+            end
+        end
     end
-    
+
     storage.interrupts[interrupt_copy_name] = table.deepcopy(edited_interrupt)
     storage.interrupts[interrupt_copy_name].name = interrupt_copy_name
 

--- a/scripts/caravan/gui/edit_interrupt.lua
+++ b/scripts/caravan/gui/edit_interrupt.lua
@@ -61,6 +61,7 @@ function P.build_subheader_frame(parent)
     -- work out how many caravans have this interrupt and store in the element tags for use in on_click
     local relevant_caravans = caravans_with_interrupt(edited_interrupt.name)
     flow.add {type = "label", name = "py_interrupt_count_label", caption = {"caravan-gui.interrupt-count", table_size(relevant_caravans)}, style = "clickable_squashable_label", tags = {name = edited_interrupt.name, ids = relevant_caravans}}.style.horizontal_align = "right"
+    flow.add {type = "sprite-button", name = "py_duplicate_interrupt_button", style = "tool_button", sprite = "utility/copy", tooltip = {"caravan-gui.duplicate-interrupt"}}
     -- handle deletion
     flow.add {type = "label", visible = false, name = "py_delete_interrupt_confirm", caption = {"caravan-gui.confirm-deletion"}}
     flow.add {type = "sprite-button", name = "py_delete_interrupt_button", style = "tool_button_red", sprite = "utility/trash", tooltip = {"caravan-gui.delete-interrupt"}, tags = {interrupt_name = edited_interrupt.name}}


### PR DESCRIPTION
Adds a button to the Edit Interrupt window that duplicates the currently opened interrupt, adds it to the selected caravan, and switches to editing that duplicate. Closes pyanodon/pybugreports#1245, though parameters aren't supported.

<img width="1297" height="627" alt="image" src="https://github.com/user-attachments/assets/72857ec5-72b1-4b3a-b270-2742dee616df" />
<br/>
<br/>
<img width="1295" height="630" alt="image" src="https://github.com/user-attachments/assets/ba4d2132-fca3-4002-b84d-94b4b85a7707" />  
<br/>
<br/>

- The duplicate will have an * appended to the end.
  - Unless the name text field was being edited, in which case it will have that name instead. 
- Any unsaved changes made in the Edit Interrupt window will be applied to the duplicate, leaving the original interrupt unchanged. Think of it like "Save As" vs. "Save".
- I originally wanted to go with the "name copy", "name copy (2)" naming scheme used in windows, but I couldn't figure out how to make localized names work in this case, since here it's being used as both the actual name and the internal lua key, so I kept getting a "Value must be a string in property tree at ROOT.text" crash.
- When Delete Interrupt is clicked, the duplicate button is hidden until the deletion is confirmed or not.