### PR TITLE
Reorganized many alienlife items

### DIFF
--- a/prototypes/biofluid/guano.lua
+++ b/prototypes/biofluid/guano.lua
@@ -96,7 +96,7 @@ FLUID {
     flow_color = {r = 1, g = 0.5, b = 0.5},
     max_temperature = 100,
     gas_temperature = 15,
-    subgroup = "py-alienlife-fluids",
+    subgroup = "py-alienlife-gases",
     order = "d"
 }
 

--- a/prototypes/biofluid/guano.lua
+++ b/prototypes/biofluid/guano.lua
@@ -50,7 +50,7 @@ data:extend {{
     icon = "__pyalienlifegraphics2__/graphics/icons/ammonium-nitrate.png",
     icon_size = 64,
     flags = {},
-    subgroup = "py-alienlife-items",
+    subgroup = "py-alienlife-anorganics",
     order = "a",
     stack_size = 100
 }}

--- a/prototypes/fluids/chelator.lua
+++ b/prototypes/fluids/chelator.lua
@@ -8,6 +8,6 @@ FLUID {
     flow_color = {r = 1, g = 1, b = 1},
     max_temperature = 100,
     gas_temperature = 15,
-    subgroup = "py-alienlife-fluids",
+    subgroup = "py-alienlife-psc-chelator",
     order = "f"
 }

--- a/prototypes/fluids/nitrogen-mustard.lua
+++ b/prototypes/fluids/nitrogen-mustard.lua
@@ -8,6 +8,6 @@ FLUID {
     flow_color = {r = 1, g = 1, b = 1},
     max_temperature = 100,
     gas_temperature = 15,
-    subgroup = "py-alienlife-fluids",
+    subgroup = "py-alienlife-gases",
     order = "f"
 }

--- a/prototypes/fluids/psc.lua
+++ b/prototypes/fluids/psc.lua
@@ -8,6 +8,6 @@ FLUID {
     flow_color = {r = 1, g = 1, b = 1},
     max_temperature = 100,
     gas_temperature = 15,
-    subgroup = "py-alienlife-fluids",
-    order = "f"
+    subgroup = "py-alienlife-psc-chelator",
+    order = "g"
 }

--- a/prototypes/fluids/xenogenic-cells.lua
+++ b/prototypes/fluids/xenogenic-cells.lua
@@ -8,6 +8,6 @@ FLUID {
     flow_color = {r = 1, g = 1, b = 1},
     max_temperature = 100,
     gas_temperature = 15,
-    subgroup = "py-alienlife-fluids",
+    subgroup = "py-alienlife-xenogenic",
     order = "f"
 }

--- a/prototypes/item-groups.lua
+++ b/prototypes/item-groups.lua
@@ -204,12 +204,6 @@ data:extend {
     -- animals
     {
         type = "item-subgroup",
-        name = "py-alienlife-sea-sponge",
-        group = "py-alienlife",
-        order = "e",
-    },
-    {
-        type = "item-subgroup",
         name = "py-alienlife-ulric",
         group = "py-alienlife",
         order = "e-a",

--- a/prototypes/item-groups.lua
+++ b/prototypes/item-groups.lua
@@ -168,6 +168,18 @@ data:extend {
         group = "py-alienlife",
         order = "cc"
     },
+    {
+        type = "item-subgroup",
+        name = "py-alienlife-psc-chelator",
+        group = "py-alienlife",
+        order = "caa"
+    },
+    {
+        type = "item-subgroup",
+        name = "py-alienlife-xenogenic",
+        group = "py-alienlife",
+        order = "cab"
+    },
 
     -- codex
     {

--- a/prototypes/item-groups.lua
+++ b/prototypes/item-groups.lua
@@ -84,8 +84,8 @@ data:extend {
     {
         type = "item-subgroup",
         name = "py-alienlife-vatbrain",
-        group = "py-alienlife",
-        order = "ba-2"
+        group = "production",
+        order = "fb"
     },
     {
         type = "item-subgroup",
@@ -122,6 +122,18 @@ data:extend {
         name = "py-alienlife-used",
         group = "py-alienlife",
         order = "bf"
+    },
+    {
+        type = "item-subgroup",
+        name = "py-alienlife-creature-product",
+        group = "py-alienlife",
+        order = "bba"
+    },
+    {
+        type = "item-subgroup",
+        name = "py-alienlife-fertilizer",
+        group = "py-alienlife",
+        order = "bbb"
     },
 
 

--- a/prototypes/item-groups.lua
+++ b/prototypes/item-groups.lua
@@ -158,12 +158,6 @@ data:extend {
     },
     {
         type = "item-subgroup",
-        name = "py-alienlife-recipes",
-        group = "py-alienlife",
-        order = "cb"
-    },
-    {
-        type = "item-subgroup",
         name = "py-alienlife-gases",
         group = "py-alienlife",
         order = "cc"

--- a/prototypes/item-groups.lua
+++ b/prototypes/item-groups.lua
@@ -107,6 +107,12 @@ data:extend {
     },
     {
         type = "item-subgroup",
+        name = "py-alienlife-native-flora-smartfarm",
+        group = "py-alienlife",
+        order = "bc-b"
+    },
+    {
+        type = "item-subgroup",
         name = "py-alienlife-genetics",
         group = "py-alienlife",
         order = "bd"
@@ -366,15 +372,33 @@ data:extend {
     },
     {
         type = "item-subgroup",
+        name = "py-alienlife-ralesia-smartfarm",
+        group = "py-alienlife",
+        order = "f-aa"
+    },
+    {
+        type = "item-subgroup",
         name = "py-alienlife-rennea",
         group = "py-alienlife",
         order = "f-b",
     },
     {
         type = "item-subgroup",
+        name = "py-alienlife-rennea-smartfarm",
+        group = "py-alienlife",
+        order = "f-ba"
+    },
+    {
+        type = "item-subgroup",
         name = "py-alienlife-yotoi",
         group = "py-alienlife",
         order = "f-c",
+    },
+    {
+        type = "item-subgroup",
+        name = "py-alienlife-yotoi-smartfarm",
+        group = "py-alienlife",
+        order = "f-cb",
     },
     {
         type = "item-subgroup",
@@ -390,9 +414,21 @@ data:extend {
     },
     {
         type = "item-subgroup",
+        name = "py-alienlife-tuuphra-smartfarm",
+        group = "py-alienlife",
+        order = "f-da"
+    },
+    {
+        type = "item-subgroup",
         name = "py-alienlife-grod",
         group = "py-alienlife",
         order = "f-e",
+    },
+    {
+        type = "item-subgroup",
+        name = "py-alienlife-grod-smartfarm",
+        group = "py-alienlife",
+        order = "f-ea"
     },
     {
         type = "item-subgroup",
@@ -408,9 +444,21 @@ data:extend {
     },
     {
         type = "item-subgroup",
+        name = "py-alienlife-kicalk-smartfarm",
+        group = "py-alienlife",
+        order = "f-g",
+    },
+    {
+        type = "item-subgroup",
         name = "py-alienlife-cadaveric",
         group = "py-alienlife",
         order = "f-h",
+    },
+    {
+        type = "item-subgroup",
+        name = "py-alienlife-cadaveric-smartfarm",
+        group = "py-alienlife",
+        order = "f-ha",
     },
     {
         type = "item-subgroup",

--- a/prototypes/item-groups.lua
+++ b/prototypes/item-groups.lua
@@ -133,13 +133,19 @@ data:extend {
         type = "item-subgroup",
         name = "py-alienlife-creature-product",
         group = "py-alienlife",
-        order = "bba"
+        order = "bbb"
     },
     {
         type = "item-subgroup",
         name = "py-alienlife-fertilizer",
         group = "py-alienlife",
-        order = "bbb"
+        order = "bbc"
+    },
+    {
+        type = "item-subgroup",
+        name = "py-alienlife-anorganics",
+        group = "py-alienlife",
+        order = "bba"
     },
 
 

--- a/prototypes/items/energy-drink.lua
+++ b/prototypes/items/energy-drink.lua
@@ -4,7 +4,7 @@ ITEM {
     icon = "__pyalienlifegraphics__/graphics/icons/energy-drink.png",
     icon_size = 64,
     flags = {},
-    subgroup = "py-alienlife-items",
+    subgroup = "py-alienlife-anorganics",
     order = "f",
     stack_size = 100,
     capsule_action = {

--- a/prototypes/items/items.lua
+++ b/prototypes/items/items.lua
@@ -170,7 +170,7 @@ ITEM {
     icon = "__pyalienlifegraphics__/graphics/icons/fawogae-spore.png",
     icon_size = 32,
     flags = {},
-    subgroup = "py-alienlife-items",
+    subgroup = "py-alienlife-fawogae",
     order = "a",
     stack_size = 100
 }
@@ -183,7 +183,7 @@ ITEM {
         {icon = "__pyalienlifegraphics__/graphics/icons/over-mk02.png",     icon_size = 64}
     },
     flags = {},
-    subgroup = "py-alienlife-items",
+    subgroup = "py-alienlife-fawogae",
     order = "a",
     stack_size = 100
 }
@@ -196,7 +196,7 @@ ITEM {
         {icon = "__pyalienlifegraphics__/graphics/icons/over-mk03.png",     icon_size = 64}
     },
     flags = {},
-    subgroup = "py-alienlife-items",
+    subgroup = "py-alienlife-fawogae",
     order = "a",
     stack_size = 100
 }
@@ -209,7 +209,7 @@ ITEM {
         {icon = "__pyalienlifegraphics__/graphics/icons/over-mk04.png",     icon_size = 64}
     },
     flags = {},
-    subgroup = "py-alienlife-items",
+    subgroup = "py-alienlife-fawogae",
     order = "a",
     stack_size = 100
 }
@@ -220,7 +220,7 @@ ITEM {
     icon = "__pyalienlifegraphics__/graphics/icons/navens-spore.png",
     icon_size = 64,
     flags = {},
-    subgroup = "py-alienlife-items",
+    subgroup = "py-alienlife-navens",
     order = "a",
     stack_size = 100
 }
@@ -234,7 +234,7 @@ ITEM {
     },
     icon_size = 64,
     flags = {},
-    subgroup = "py-alienlife-items",
+    subgroup = "py-alienlife-navens",
     order = "a",
     stack_size = 100
 }
@@ -248,7 +248,7 @@ ITEM {
     },
     icon_size = 64,
     flags = {},
-    subgroup = "py-alienlife-items",
+    subgroup = "py-alienlife-navens",
     order = "a",
     stack_size = 100
 }
@@ -262,7 +262,7 @@ ITEM {
     },
     icon_size = 64,
     flags = {},
-    subgroup = "py-alienlife-items",
+    subgroup = "py-alienlife-navens",
     order = "a",
     stack_size = 100
 }
@@ -273,7 +273,7 @@ ITEM {
     icon = "__pyalienlifegraphics__/graphics/icons/yaedols-spores.png",
     icon_size = 64,
     flags = {},
-    subgroup = "py-alienlife-items",
+    subgroup = "py-alienlife-yaedols",
     order = "a",
     stack_size = 100
 }
@@ -286,7 +286,7 @@ ITEM {
         {icon = "__pyalienlifegraphics__/graphics/icons/over-mk02.png",      icon_size = 64}
     },
     flags = {},
-    subgroup = "py-alienlife-items",
+    subgroup = "py-alienlife-yaedols",
     order = "a",
     stack_size = 100
 }
@@ -299,7 +299,7 @@ ITEM {
         {icon = "__pyalienlifegraphics__/graphics/icons/over-mk03.png",      icon_size = 64}
     },
     flags = {},
-    subgroup = "py-alienlife-items",
+    subgroup = "py-alienlife-yaedols",
     order = "a",
     stack_size = 100
 }
@@ -312,7 +312,7 @@ ITEM {
         {icon = "__pyalienlifegraphics__/graphics/icons/over-mk04.png",      icon_size = 64}
     },
     flags = {},
-    subgroup = "py-alienlife-items",
+    subgroup = "py-alienlife-yaedols",
     order = "a",
     stack_size = 100
 }
@@ -911,7 +911,7 @@ ITEM {
         {size = 64, filename = "__pyalienlifegraphics__/graphics/icons/mip/guts-07.png", scale = 0.66}
     },
     flags = {},
-    subgroup = "py-alienlife-items",
+    subgroup = "py-alienlife-creature-product",
     order = "a",
     stack_size = 100
 }
@@ -948,7 +948,7 @@ ITEM {
         {size = 64, filename = "__pyalienlifegraphics__/graphics/icons/mip/brain-06.png", scale = 0.66}
     },
     flags = {},
-    subgroup = "py-alienlife-items",
+    subgroup = "py-alienlife-creature-product",
     order = "a",
     stack_size = 100
 }
@@ -971,7 +971,7 @@ ITEM {
     fuel_acceleration_multiplier = 1,
     fuel_top_speed_multiplier = 1,
     flags = {},
-    subgroup = "py-alienlife-items",
+    subgroup = "py-alienlife-creature-product",
     order = "a",
     stack_size = 100
 }
@@ -991,7 +991,7 @@ ITEM {
         {size = 64, filename = "__pyalienlifegraphics__/graphics/icons/mip/bones-07.png", scale = 0.66}
     },
     flags = {},
-    subgroup = "py-alienlife-items",
+    subgroup = "py-alienlife-creature-product",
     order = "a",
     stack_size = 100
 }
@@ -1002,7 +1002,7 @@ ITEM {
     icon = "__pyalienlifegraphics__/graphics/icons/bonemeal.png",
     icon_size = 64,
     flags = {},
-    subgroup = "py-alienlife-items",
+    subgroup = "py-alienlife-creature-product",
     order = "a",
     stack_size = 100
 }
@@ -1013,7 +1013,7 @@ ITEM {
     icon = "__pyalienlifegraphics__/graphics/icons/mukmoux-fat.png",
     icon_size = 64,
     flags = {},
-    subgroup = "py-alienlife-items",
+    subgroup = "py-alienlife-creature-product",
     order = "a",
     stack_size = 100
 }
@@ -1061,7 +1061,7 @@ ITEM {
     icon = "__pyalienlifegraphics__/graphics/icons/chitin.png",
     icon_size = 64,
     flags = {},
-    subgroup = "py-alienlife-items",
+    subgroup = "py-alienlife-creature-product",
     order = "a",
     stack_size = 100
 }
@@ -1072,7 +1072,7 @@ ITEM {
     icon = "__pyalienlifegraphics__/graphics/icons/carapace.png",
     icon_size = 64,
     flags = {},
-    subgroup = "py-alienlife-items",
+    subgroup = "py-alienlife-creature-product",
     order = "a",
     stack_size = 100
 }
@@ -1083,7 +1083,7 @@ ITEM {
     icon = "__pyalienlifegraphics__/graphics/icons/skin.png",
     icon_size = 64,
     flags = {},
-    subgroup = "py-alienlife-items",
+    subgroup = "py-alienlife-creature-product",
     order = "h",
     stack_size = 100
 }
@@ -1896,7 +1896,7 @@ ITEM {
     icon = "__pyalienlifegraphics__/graphics/icons/fertilizer.png",
     icon_size = 32,
     flags = {},
-    subgroup = "py-alienlife-items",
+    subgroup = "py-alienlife-fertilizer",
     order = "h",
     stack_size = 100
 }
@@ -3076,7 +3076,7 @@ ITEM {
     icon = "__pyalienlifegraphics__/graphics/icons/fish-eggs.png",
     icon_size = 64,
     flags = {},
-    subgroup = "py-alienlife-items",
+    subgroup = "py-alienlife-fish",
     order = "x",
     stack_size = 100
 }
@@ -3090,7 +3090,7 @@ ITEM {
     },
     icon_size = 64,
     flags = {},
-    subgroup = "py-alienlife-items",
+    subgroup = "py-alienlife-fish",
     order = "x",
     stack_size = 100
 }
@@ -3104,7 +3104,7 @@ ITEM {
     },
     icon_size = 64,
     flags = {},
-    subgroup = "py-alienlife-items",
+    subgroup = "py-alienlife-fish",
     order = "x",
     stack_size = 100
 }
@@ -3118,7 +3118,7 @@ ITEM {
     },
     icon_size = 64,
     flags = {},
-    subgroup = "py-alienlife-items",
+    subgroup = "py-alienlife-fish",
     order = "x",
     stack_size = 100
 }
@@ -4117,7 +4117,7 @@ ITEM {
     icon = "__pyalienlifegraphics__/graphics/icons/laboratory-grown-brain.png",
     icon_size = 64,
     flags = {},
-    subgroup = "py-alienlife-items",
+    subgroup = "py-alienlife-creature-product",
     order = "k",
     stack_size = 100
 }
@@ -4128,7 +4128,7 @@ ITEM {
     icon = "__pyalienlifegraphics__/graphics/icons/tissue-engineered-fat.png",
     icon_size = 64,
     flags = {},
-    subgroup = "py-alienlife-items",
+    subgroup = "py-alienlife-creature-product",
     order = "k",
     stack_size = 100
 }
@@ -4139,7 +4139,7 @@ ITEM {
     icon = "__pyalienlifegraphics__/graphics/icons/in-vitro-meat.png",
     icon_size = 64,
     flags = {},
-    subgroup = "py-alienlife-items",
+    subgroup = "py-alienlife-creature-product",
     order = "k",
     stack_size = 100
 }
@@ -4150,7 +4150,7 @@ ITEM {
     icon = "__pyalienlifegraphics__/graphics/icons/biomimetic-skin.png",
     icon_size = 64,
     flags = {},
-    subgroup = "py-alienlife-items",
+    subgroup = "py-alienlife-creature-product",
     order = "k",
     stack_size = 100
 }
@@ -4161,7 +4161,7 @@ ITEM {
     icon = "__pyalienlifegraphics__/graphics/icons/bioartificial-guts.png",
     icon_size = 64,
     flags = {},
-    subgroup = "py-alienlife-items",
+    subgroup = "py-alienlife-creature-product",
     order = "k",
     stack_size = 100
 }
@@ -4172,7 +4172,7 @@ ITEM {
     icon = "__pyalienlifegraphics__/graphics/icons/scafold-free-bones.png",
     icon_size = 64,
     flags = {},
-    subgroup = "py-alienlife-items",
+    subgroup = "py-alienlife-creature-product",
     order = "k",
     stack_size = 100
 }
@@ -4183,7 +4183,7 @@ ITEM {
     icon = "__pyalienlifegraphics__/graphics/icons/bio-scafold.png",
     icon_size = 64,
     flags = {},
-    subgroup = "py-alienlife-items",
+    subgroup = "py-alienlife-creature-product",
     order = "k",
     stack_size = 100
 }
@@ -4269,7 +4269,7 @@ ITEM {
     icon = "__pyalienlifegraphics__/graphics/icons/bhoddos-spore.png",
     icon_size = 64,
     flags = {},
-    subgroup = "py-alienlife-items",
+    subgroup = "py-alienlife-bhoddos",
     order = "a",
     stack_size = 100
 }
@@ -4283,7 +4283,7 @@ ITEM {
     },
     icon_size = 64,
     flags = {},
-    subgroup = "py-alienlife-items",
+    subgroup = "py-alienlife-bhoddos",
     order = "a",
     stack_size = 100
 }
@@ -4297,7 +4297,7 @@ ITEM {
     },
     icon_size = 64,
     flags = {},
-    subgroup = "py-alienlife-items",
+    subgroup = "py-alienlife-bhoddos",
     order = "a",
     stack_size = 100
 }
@@ -4311,7 +4311,7 @@ ITEM {
     },
     icon_size = 64,
     flags = {},
-    subgroup = "py-alienlife-items",
+    subgroup = "py-alienlife-bhoddos",
     order = "a",
     stack_size = 100
 }

--- a/prototypes/items/items.lua
+++ b/prototypes/items/items.lua
@@ -1799,7 +1799,7 @@ ITEM {
     icon = "__pyalienlifegraphics__/graphics/icons/sea-sponge-sprouts.png",
     icon_size = 64,
     flags = {},
-    subgroup = "py-alienlife-sea-sponge",
+    subgroup = "py-alienlife-sponge",
     order = "a",
     stack_size = 100
 }
@@ -1813,7 +1813,7 @@ ITEM {
     },
     icon_size = 64,
     flags = {},
-    subgroup = "py-alienlife-sea-sponge",
+    subgroup = "py-alienlife-sponge",
     order = "a",
     stack_size = 100
 }
@@ -1827,7 +1827,7 @@ ITEM {
     },
     icon_size = 64,
     flags = {},
-    subgroup = "py-alienlife-sea-sponge",
+    subgroup = "py-alienlife-sponge",
     order = "a",
     stack_size = 100
 }
@@ -1841,7 +1841,7 @@ ITEM {
     },
     icon_size = 64,
     flags = {},
-    subgroup = "py-alienlife-sea-sponge",
+    subgroup = "py-alienlife-sponge",
     order = "a",
     stack_size = 100
 }
@@ -6231,7 +6231,7 @@ ITEM {
     category = "sponge",
     tier = 1,
     flags = {},
-    subgroup = "py-alienlife-sea-sponge",
+    subgroup = "py-alienlife-sponge",
     order = "sa",
     stack_size = 50,
     effect = {pollution = 1, speed = 1},
@@ -6248,7 +6248,7 @@ ITEM {
     category = "sponge",
     tier = 2,
     flags = {},
-    subgroup = "py-alienlife-sea-sponge",
+    subgroup = "py-alienlife-sponge",
     order = "sb",
     stack_size = 50,
     effect = {pollution = 1, speed = 2},
@@ -6265,7 +6265,7 @@ ITEM {
     category = "sponge",
     tier = 3,
     flags = {},
-    subgroup = "py-alienlife-sea-sponge",
+    subgroup = "py-alienlife-sponge",
     order = "sc",
     stack_size = 50,
     effect = {pollution = 1, speed = 3},
@@ -6282,7 +6282,7 @@ ITEM {
     category = "sponge",
     tier = 4,
     flags = {},
-    subgroup = "py-alienlife-sea-sponge",
+    subgroup = "py-alienlife-sponge",
     order = "sd",
     stack_size = 50,
     effect = {pollution = 1, speed = 4},

--- a/prototypes/items/items.lua
+++ b/prototypes/items/items.lua
@@ -49,7 +49,7 @@ ITEM {
     icon = "__pyalienlifegraphics__/graphics/icons/cobalt-oxide.png",
     icon_size = 64,
     flags = {},
-    subgroup = "py-alienlife-items",
+    subgroup = "py-alienlife-anorganics",
     order = "a",
     stack_size = 100
 }
@@ -60,7 +60,7 @@ ITEM {
     icon = "__pyalienlifegraphics__/graphics/icons/cobalt-extract.png",
     icon_size = 64,
     flags = {},
-    subgroup = "py-alienlife-items",
+    subgroup = "py-alienlife-anorganics",
     order = "a",
     stack_size = 100
 }
@@ -71,7 +71,7 @@ ITEM {
     icon = "__pyalienlifegraphics__/graphics/icons/co-sulfate.png",
     icon_size = 64,
     flags = {},
-    subgroup = "py-alienlife-items",
+    subgroup = "py-alienlife-anorganics",
     order = "a",
     stack_size = 100
 }
@@ -82,7 +82,7 @@ ITEM {
     icon = "__pyalienlifegraphics__/graphics/icons/co-sulfate-02.png",
     icon_size = 64,
     flags = {},
-    subgroup = "py-alienlife-items",
+    subgroup = "py-alienlife-anorganics",
     order = "a",
     stack_size = 100
 }
@@ -93,7 +93,7 @@ ITEM {
     icon = "__pyalienlifegraphics__/graphics/icons/cobalt-nx.png",
     icon_size = 64,
     flags = {},
-    subgroup = "py-alienlife-items",
+    subgroup = "py-alienlife-anorganics",
     order = "a",
     stack_size = 100
 }
@@ -104,7 +104,7 @@ ITEM {
     icon = "__pyalienlifegraphics__/graphics/icons/mixed-ores.png",
     icon_size = 32,
     flags = {},
-    subgroup = "py-alienlife-items",
+    subgroup = "py-alienlife-anorganics",
     order = "a",
     stack_size = 100
 }
@@ -350,7 +350,7 @@ ITEM {
     icon = "__pyalienlifegraphics__/graphics/icons/empty-petri-dish.png",
     icon_size = 64,
     flags = {},
-    subgroup = "py-alienlife-items",
+    subgroup = "py-alienlife-anorganics",
     order = "a",
     stack_size = 100
 }
@@ -427,7 +427,7 @@ ITEM {
     icon = "__pyalienlifegraphics__/graphics/icons/bio-container.png",
     icon_size = 64,
     flags = {},
-    subgroup = "py-alienlife-items",
+    subgroup = "py-alienlife-anorganics",
     order = "b",
     stack_size = 100
 }
@@ -839,7 +839,7 @@ ITEM {
     icon = "__pyalienlifegraphics__/graphics/icons/cage.png",
     icon_size = 64,
     flags = {},
-    subgroup = "py-alienlife-items",
+    subgroup = "py-alienlife-anorganics",
     order = "a",
     stack_size = 100
 }
@@ -1093,7 +1093,7 @@ ITEM {
     icon = "__pyalienlifegraphics__/graphics/icons/neuroprocessor.png",
     icon_size = 64,
     flags = {},
-    subgroup = "py-alienlife-items",
+    subgroup = "py-alienlife-anorganics",
     order = "h",
     stack_size = 100
 }
@@ -1148,7 +1148,7 @@ ITEM {
     icon = "__pyalienlifegraphics__/graphics/icons/magnetic-beads.png",
     icon_size = 64,
     flags = {},
-    subgroup = "py-alienlife-items",
+    subgroup = "py-alienlife-anorganics",
     order = "h",
     stack_size = 100
 }
@@ -1170,7 +1170,7 @@ ITEM {
     icon = "__pyalienlifegraphics__/graphics/icons/nanofibrils.png",
     icon_size = 64,
     flags = {},
-    subgroup = "py-alienlife-items",
+    subgroup = "py-alienlife-anorganics",
     order = "h",
     stack_size = 100
 }
@@ -1181,7 +1181,7 @@ ITEM {
     icon = "__pyalienlifegraphics__/graphics/icons/empty-barrel-milk.png",
     icon_size = 64,
     flags = {},
-    subgroup = "py-alienlife-items",
+    subgroup = "py-alienlife-anorganics",
     order = "h",
     stack_size = 100
 }
@@ -1192,7 +1192,7 @@ ITEM {
     icon = "__pyalienlifegraphics__/graphics/icons/barrel-milk.png",
     icon_size = 64,
     flags = {},
-    subgroup = "py-alienlife-items",
+    subgroup = "py-alienlife-anorganics",
     order = "h",
     stack_size = 100
 }
@@ -2046,7 +2046,7 @@ ITEM {
     icon = "__pyalienlifegraphics__/graphics/icons/cobalt-fluoride.png",
     icon_size = 64,
     flags = {},
-    subgroup = "py-alienlife-items",
+    subgroup = "py-alienlife-anorganics",
     order = "h",
     stack_size = 100
 }
@@ -4590,7 +4590,7 @@ ITEM {
     icon = "__pyalienlifegraphics__/graphics/icons/empty-neuromorphic-chip.png",
     icon_size = 64,
     flags = {},
-    subgroup = "py-alienlife-items",
+    subgroup = "py-alienlife-anorganics",
     order = "a",
     stack_size = 100
 }
@@ -4601,7 +4601,7 @@ ITEM {
     icon = "__pyalienlifegraphics__/graphics/icons/neuromorphic-chip.png",
     icon_size = 64,
     flags = {},
-    subgroup = "py-alienlife-items",
+    subgroup = "py-alienlife-anorganics",
     order = "a",
     stack_size = 100
 }
@@ -5377,7 +5377,7 @@ ITEM {
     icon = "__pyalienlifegraphics__/graphics/icons/casein.png",
     icon_size = 64,
     flags = {},
-    subgroup = "py-alienlife-items",
+    subgroup = "py-alienlife-anorganics",
     order = "a",
     stack_size = 100
 }
@@ -5682,7 +5682,7 @@ ITEM {
     icon = "__pyalienlifegraphics3__/graphics/icons/pesticide-mk01.png",
     icon_size = 64,
     flags = {},
-    subgroup = "py-alienlife-items",
+    subgroup = "py-alienlife-anorganics",
     order = "d",
     stack_size = 100
 }
@@ -5693,7 +5693,7 @@ ITEM {
     icon = "__pyalienlifegraphics3__/graphics/icons/pesticide-mk02.png",
     icon_size = 64,
     flags = {},
-    subgroup = "py-alienlife-items",
+    subgroup = "py-alienlife-anorganics",
     order = "d",
     stack_size = 100
 }
@@ -9136,7 +9136,7 @@ ITEM {
     icon = "__pyalienlifegraphics3__/graphics/icons/empty-planter-box.png",
     icon_size = 64,
     flags = {},
-    subgroup = "py-alienlife-items",
+    subgroup = "py-alienlife-anorganics",
     order = "x",
     stack_size = 100
 }
@@ -9147,7 +9147,7 @@ ITEM {
     icon = "__pyalienlifegraphics3__/graphics/icons/planter-box.png",
     icon_size = 64,
     flags = {},
-    subgroup = "py-alienlife-items",
+    subgroup = "py-alienlife-anorganics",
     order = "x",
     stack_size = 100
 }

--- a/prototypes/items/items.lua
+++ b/prototypes/items/items.lua
@@ -449,7 +449,7 @@ ITEM {
     icon = "__pyalienlifegraphics__/graphics/icons/cocoon.png",
     icon_size = 64,
     flags = {},
-    subgroup = "py-alienlife-recipes",
+    subgroup = "py-alienlife-vrauks",
     order = "b",
     stack_size = 100
 }
@@ -463,7 +463,7 @@ ITEM {
     },
     icon_size = 64,
     flags = {},
-    subgroup = "py-alienlife-recipes",
+    subgroup = "py-alienlife-vrauks",
     order = "b",
     stack_size = 100
 }
@@ -477,7 +477,7 @@ ITEM {
     },
     icon_size = 64,
     flags = {},
-    subgroup = "py-alienlife-recipes",
+    subgroup = "py-alienlife-vrauks",
     order = "b",
     stack_size = 100
 }
@@ -491,7 +491,7 @@ ITEM {
     },
     icon_size = 64,
     flags = {},
-    subgroup = "py-alienlife-recipes",
+    subgroup = "py-alienlife-vrauks",
     order = "b",
     stack_size = 100
 }

--- a/prototypes/items/items2.lua
+++ b/prototypes/items/items2.lua
@@ -481,7 +481,7 @@ ITEM {
     icon = "__pyalienlifegraphics2__/graphics/icons/brain-cartridge-01.png",
     icon_size = 64,
     flags = {},
-    subgroup = "py-alienlife-used",
+    subgroup = "py-alienlife-vatbrain",
     order = "aa",
     stack_size = 50
 }
@@ -492,7 +492,7 @@ ITEM {
     icon = "__pyalienlifegraphics2__/graphics/icons/brain-cartridge-02.png",
     icon_size = 64,
     flags = {},
-    subgroup = "py-alienlife-used",
+    subgroup = "py-alienlife-vatbrain",
     order = "ab",
     stack_size = 50
 }
@@ -503,7 +503,7 @@ ITEM {
     icon = "__pyalienlifegraphics2__/graphics/icons/brain-cartridge-03.png",
     icon_size = 64,
     flags = {},
-    subgroup = "py-alienlife-used",
+    subgroup = "py-alienlife-vatbrain",
     order = "ac",
     stack_size = 50
 }
@@ -514,7 +514,7 @@ ITEM {
     icon = "__pyalienlifegraphics2__/graphics/icons/brain-cartridge-04.png",
     icon_size = 64,
     flags = {},
-    subgroup = "py-alienlife-used",
+    subgroup = "py-alienlife-vatbrain",
     order = "ad",
     stack_size = 50
 }

--- a/prototypes/items/items2.lua
+++ b/prototypes/items/items2.lua
@@ -426,7 +426,7 @@ ITEM {
         {size = 64, filename = "__pyalienlifegraphics__/graphics/icons/mip/bio/29.png", scale = 1}
     },
     flags = {},
-    subgroup = "py-alienlife-items",
+    subgroup = "py-alienlife-native-flora-smartfarm",
     order = "a",
     stack_size = 50
 }

--- a/prototypes/items/items2.lua
+++ b/prototypes/items/items2.lua
@@ -43,7 +43,7 @@ ITEM {
     icon = "__pyalienlifegraphics__/graphics/icons/green-sic.png",
     icon_size = 64,
     flags = {},
-    subgroup = "py-alienlife-items",
+    subgroup = "py-alienlife-anorganics",
     order = "a",
     stack_size = 100
 }
@@ -54,7 +54,7 @@ ITEM {
     icon = "__pyalienlifegraphics__/graphics/icons/sic.png",
     icon_size = 64,
     flags = {},
-    subgroup = "py-alienlife-items",
+    subgroup = "py-alienlife-anorganics",
     order = "a",
     stack_size = 100
 }
@@ -65,7 +65,7 @@ ITEM {
     icon = "__pyalienlifegraphics__/graphics/icons/quartz-tube.png",
     icon_size = 64,
     flags = {},
-    subgroup = "py-alienlife-items",
+    subgroup = "py-alienlife-anorganics",
     order = "a",
     stack_size = 100
 }
@@ -76,7 +76,7 @@ ITEM {
     icon = "__pyalienlifegraphics__/graphics/icons/mosfet.png",
     icon_size = 64,
     flags = {},
-    subgroup = "py-alienlife-items",
+    subgroup = "py-alienlife-anorganics",
     order = "a",
     stack_size = 100
 }
@@ -87,7 +87,7 @@ ITEM {
     icon = "__pyalienlifegraphics__/graphics/icons/nisi.png",
     icon_size = 64,
     flags = {},
-    subgroup = "py-alienlife-items",
+    subgroup = "py-alienlife-anorganics",
     order = "a",
     stack_size = 100
 }

--- a/prototypes/recipes/cadaveric-arum/recipes-arum-megafarm.lua
+++ b/prototypes/recipes/cadaveric-arum/recipes-arum-megafarm.lua
@@ -4,6 +4,7 @@ RECIPE {
     type = "recipe",
     name = "arum-super-1",
     category = "arum-farm",
+    subgroup = "py-alienlife-cadaveric-smartfarm",
     enabled = false,
     energy_required = 100,
     ingredients = {
@@ -20,6 +21,7 @@ RECIPE {
     type = "recipe",
     name = "arum-super-2",
     category = "arum-farm",
+    subgroup = "py-alienlife-cadaveric-smartfarm",
     enabled = false,
     energy_required = 100,
     ingredients = {
@@ -37,6 +39,7 @@ RECIPE {
     type = "recipe",
     name = "arum-super-3",
     category = "arum-farm",
+    subgroup = "py-alienlife-cadaveric-smartfarm",
     enabled = false,
     energy_required = 100,
     ingredients = {
@@ -55,6 +58,7 @@ RECIPE {
     type = "recipe",
     name = "arum-super-4",
     category = "arum-farm",
+    subgroup = "py-alienlife-cadaveric-smartfarm",
     enabled = false,
     energy_required = 100,
     ingredients = {
@@ -75,6 +79,7 @@ RECIPE {
     type = "recipe",
     name = "arum-super-5",
     category = "arum-farm",
+    subgroup = "py-alienlife-cadaveric-smartfarm",
     enabled = false,
     energy_required = 100,
     ingredients = {
@@ -96,6 +101,7 @@ RECIPE {
     type = "recipe",
     name = "arum-super-6",
     category = "arum-farm",
+    subgroup = "py-alienlife-cadaveric-smartfarm",
     enabled = false,
     energy_required = 100,
     ingredients = {
@@ -117,6 +123,7 @@ RECIPE {
     type = "recipe",
     name = "arum-super-7",
     category = "arum-farm",
+    subgroup = "py-alienlife-cadaveric-smartfarm",
     enabled = false,
     energy_required = 100,
     ingredients = {
@@ -138,6 +145,7 @@ RECIPE {
     type = "recipe",
     name = "arum-super-8",
     category = "arum-farm",
+    subgroup = "py-alienlife-cadaveric-smartfarm",
     enabled = false,
     energy_required = 100,
     ingredients = {
@@ -159,6 +167,7 @@ RECIPE {
     type = "recipe",
     name = "arum-super-9",
     category = "arum-farm",
+    subgroup = "py-alienlife-cadaveric-smartfarm",
     enabled = false,
     energy_required = 100,
     ingredients = {
@@ -181,6 +190,7 @@ RECIPE {
     type = "recipe",
     name = "arum-super-10",
     category = "arum-farm",
+    subgroup = "py-alienlife-cadaveric-smartfarm",
     enabled = false,
     energy_required = 60,
     ingredients = {

--- a/prototypes/recipes/cottongut/recipes-cottongut-science.lua
+++ b/prototypes/recipes/cottongut/recipes-cottongut-science.lua
@@ -15,7 +15,6 @@ RECIPE {
         {type = "item", name = "solidified-sarcorus", amount = 3},
     },
     main_product = "solidified-sarcorus",
-    subgroup = "py-alienlife-items",
     order = "a1"
 }:add_unlock("cottongut-science-mk01")
 
@@ -38,7 +37,6 @@ RECIPE {
         {type = "item", name = "solidified-sarcorus", amount = 5},
     },
     main_product = "paragen",
-    subgroup = "py-alienlife-items",
     order = "a1"
 }:add_unlock("cottongut-science-mk02")
 
@@ -65,7 +63,6 @@ RECIPE {
         {type = "item", name = "solidified-sarcorus", amount = 7},
     },
     main_product = "negasium",
-    subgroup = "py-alienlife-items",
     order = "a1"
 }:add_unlock("cottongut-science-mk03"):add_ingredient {type = "item", name = "kicalk-seeds", amount = 1}
 
@@ -94,7 +91,6 @@ RECIPE {
         {type = "item", name = "solidified-sarcorus",    amount = 9},
     },
     main_product = "nonconductive-phazogen",
-    subgroup = "py-alienlife-items",
     order = "a1"
 }:add_unlock("cottongut-science-mk04")
 
@@ -125,6 +121,5 @@ RECIPE {
         {type = "item", name = "solidified-sarcorus",    amount = 11},
     },
     main_product = "denatured-seismite",
-    subgroup = "py-alienlife-items",
     order = "a1"
 }:add_unlock("cottongut-science-mk05"):add_ingredient {type = "item", name = "kicalk-seeds", amount = 20}

--- a/prototypes/recipes/grod/recipes-grod-megafarm.lua
+++ b/prototypes/recipes/grod/recipes-grod-megafarm.lua
@@ -4,6 +4,7 @@ RECIPE {
     type = "recipe",
     name = "grod-super-1",
     category = "grod-farm",
+    subgroup = "py-alienlife-grod-smartfarm",
     enabled = false,
     energy_required = 100,
     ingredients = {
@@ -19,6 +20,7 @@ RECIPE {
     type = "recipe",
     name = "grod-super-2",
     category = "grod-farm",
+    subgroup = "py-alienlife-grod-smartfarm",
     enabled = false,
     energy_required = 100,
     ingredients = {
@@ -35,6 +37,7 @@ RECIPE {
     type = "recipe",
     name = "grod-super-3",
     category = "grod-farm",
+    subgroup = "py-alienlife-grod-smartfarm",
     enabled = false,
     energy_required = 100,
     ingredients = {
@@ -52,6 +55,7 @@ RECIPE {
     type = "recipe",
     name = "grod-super-4",
     category = "grod-farm",
+    subgroup = "py-alienlife-grod-smartfarm",
     enabled = false,
     energy_required = 100,
     ingredients = {
@@ -70,6 +74,7 @@ RECIPE {
     type = "recipe",
     name = "grod-super-5",
     category = "grod-farm",
+    subgroup = "py-alienlife-grod-smartfarm",
     enabled = false,
     energy_required = 100,
     ingredients = {
@@ -89,6 +94,7 @@ RECIPE {
     type = "recipe",
     name = "grod-super-6",
     category = "grod-farm",
+    subgroup = "py-alienlife-grod-smartfarm",
     enabled = false,
     energy_required = 100,
     ingredients = {
@@ -109,6 +115,7 @@ RECIPE {
     type = "recipe",
     name = "grod-super-7",
     category = "grod-farm",
+    subgroup = "py-alienlife-grod-smartfarm",
     enabled = false,
     energy_required = 100,
     ingredients = {
@@ -130,6 +137,7 @@ RECIPE {
     type = "recipe",
     name = "grod-super-8",
     category = "grod-farm",
+    subgroup = "py-alienlife-grod-smartfarm",
     enabled = false,
     energy_required = 100,
     ingredients = {
@@ -152,6 +160,7 @@ RECIPE {
     type = "recipe",
     name = "grod-super-10",
     category = "grod-farm",
+    subgroup = "py-alienlife-grod-smartfarm",
     enabled = false,
     energy_required = 60,
     ingredients = {

--- a/prototypes/recipes/kicalk/recipes-kicalk-megafarm.lua
+++ b/prototypes/recipes/kicalk/recipes-kicalk-megafarm.lua
@@ -4,6 +4,7 @@ RECIPE {
     type = "recipe",
     name = "kicalk-super-1",
     category = "kicalk-farm",
+    subgroup = "py-alienlife-kicalk-smartfarm",
     enabled = false,
     energy_required = 100,
     ingredients = {
@@ -20,6 +21,7 @@ RECIPE {
     type = "recipe",
     name = "kicalk-super-2",
     category = "kicalk-farm",
+    subgroup = "py-alienlife-kicalk-smartfarm",
     enabled = false,
     energy_required = 100,
     ingredients = {
@@ -37,6 +39,7 @@ RECIPE {
     type = "recipe",
     name = "kicalk-super-3",
     category = "kicalk-farm",
+    subgroup = "py-alienlife-kicalk-smartfarm",
     enabled = false,
     energy_required = 100,
     ingredients = {
@@ -55,6 +58,7 @@ RECIPE {
     type = "recipe",
     name = "kicalk-super-4",
     category = "kicalk-farm",
+    subgroup = "py-alienlife-kicalk-smartfarm",
     enabled = false,
     energy_required = 100,
     ingredients = {
@@ -75,6 +79,7 @@ RECIPE {
     type = "recipe",
     name = "kicalk-super-5",
     category = "kicalk-farm",
+    subgroup = "py-alienlife-kicalk-smartfarm",
     enabled = false,
     energy_required = 100,
     ingredients = {
@@ -96,6 +101,7 @@ RECIPE {
     type = "recipe",
     name = "kicalk-super-6",
     category = "kicalk-farm",
+    subgroup = "py-alienlife-kicalk-smartfarm",
     enabled = false,
     energy_required = 100,
     ingredients = {
@@ -117,6 +123,7 @@ RECIPE {
     type = "recipe",
     name = "kicalk-super-7",
     category = "kicalk-farm",
+    subgroup = "py-alienlife-kicalk-smartfarm",
     enabled = false,
     energy_required = 100,
     ingredients = {
@@ -138,6 +145,7 @@ RECIPE {
     type = "recipe",
     name = "kicalk-super-8",
     category = "kicalk-farm",
+    subgroup = "py-alienlife-kicalk-smartfarm",
     enabled = false,
     energy_required = 100,
     ingredients = {
@@ -159,6 +167,7 @@ RECIPE {
     type = "recipe",
     name = "kicalk-super-9",
     category = "kicalk-farm",
+    subgroup = "py-alienlife-kicalk-smartfarm",
     enabled = false,
     energy_required = 100,
     ingredients = {
@@ -181,6 +190,7 @@ RECIPE {
     type = "recipe",
     name = "kicalk-super-10",
     category = "kicalk-farm",
+    subgroup = "py-alienlife-kicalk-smartfarm",
     enabled = false,
     energy_required = 60,
     ingredients = {

--- a/prototypes/recipes/ralesia/recipes-ralesia-megafarm.lua
+++ b/prototypes/recipes/ralesia/recipes-ralesia-megafarm.lua
@@ -4,6 +4,7 @@ RECIPE {
     type = "recipe",
     name = "ralesia-super-1",
     category = "ralesia-farm",
+    subgroup = "py-alienlife-ralesia-smartfarm",
     enabled = false,
     energy_required = 80,
     ingredients = {
@@ -22,6 +23,7 @@ RECIPE {
     type = "recipe",
     name = "ralesia-super-2",
     category = "ralesia-farm",
+    subgroup = "py-alienlife-ralesia-smartfarm",
     enabled = false,
     energy_required = 80,
     ingredients = {
@@ -40,6 +42,7 @@ RECIPE {
     type = "recipe",
     name = "ralesia-super-3",
     category = "ralesia-farm",
+    subgroup = "py-alienlife-ralesia-smartfarm",
     enabled = false,
     energy_required = 80,
     ingredients = {
@@ -58,6 +61,7 @@ RECIPE {
     type = "recipe",
     name = "ralesia-super-4",
     category = "ralesia-farm",
+    subgroup = "py-alienlife-ralesia-smartfarm",
     enabled = false,
     energy_required = 80,
     ingredients = {
@@ -77,6 +81,7 @@ RECIPE {
     type = "recipe",
     name = "ralesia-super-5",
     category = "ralesia-farm",
+    subgroup = "py-alienlife-ralesia-smartfarm",
     enabled = false,
     energy_required = 80,
     ingredients = {
@@ -96,6 +101,7 @@ RECIPE {
     type = "recipe",
     name = "ralesia-super-6",
     category = "ralesia-farm",
+    subgroup = "py-alienlife-ralesia-smartfarm",
     enabled = false,
     energy_required = 80,
     ingredients = {
@@ -116,6 +122,7 @@ RECIPE {
     type = "recipe",
     name = "ralesia-super-7",
     category = "ralesia-farm",
+    subgroup = "py-alienlife-ralesia-smartfarm",
     enabled = false,
     energy_required = 80,
     ingredients = {
@@ -134,6 +141,7 @@ RECIPE {
     type = "recipe",
     name = "ralesia-super-10",
     category = "ralesia-farm",
+    subgroup = "py-alienlife-ralesia-smartfarm",
     enabled = false,
     energy_required = 80,
     ingredients = {

--- a/prototypes/recipes/recipes-vat.lua
+++ b/prototypes/recipes/recipes-vat.lua
@@ -169,7 +169,7 @@ RECIPE {
     results = {},
     icon = "__pyalienlifegraphics2__/graphics/icons/brain-cartridge-01.png",
     icon_size = 64,
-    subgroup = "py-alienlife-used",
+    subgroup = "py-alienlife-vatbrain",
     order = "aa",
     hidden_in_factoriopedia = true
 }:add_unlock("vatbrain-mk01")
@@ -186,7 +186,7 @@ RECIPE {
     results = {},
     icon = "__pyalienlifegraphics2__/graphics/icons/brain-cartridge-02.png",
     icon_size = 64,
-    subgroup = "py-alienlife-used",
+    subgroup = "py-alienlife-vatbrain",
     order = "ab",
     hidden_in_factoriopedia = true
 }:add_unlock("vatbrain-mk02")
@@ -203,7 +203,7 @@ RECIPE {
     results = {},
     icon = "__pyalienlifegraphics2__/graphics/icons/brain-cartridge-03.png",
     icon_size = 64,
-    subgroup = "py-alienlife-used",
+    subgroup = "py-alienlife-vatbrain",
     order = "ac",
     hidden_in_factoriopedia = true
 }:add_unlock("vatbrain-mk03")
@@ -220,7 +220,7 @@ RECIPE {
     results = {},
     icon = "__pyalienlifegraphics2__/graphics/icons/brain-cartridge-04.png",
     icon_size = 64,
-    subgroup = "py-alienlife-used",
+    subgroup = "py-alienlife-vatbrain",
     order = "ad",
     hidden_in_factoriopedia = true
 }:add_unlock("vatbrain-mk04")

--- a/prototypes/recipes/recipes.lua
+++ b/prototypes/recipes/recipes.lua
@@ -2543,7 +2543,6 @@ RECIPE {
     --main_product = "chloral",
     icon = "__pyalienlifegraphics__/graphics/icons/green-sic-recrush.png",
     icon_size = 64,
-    subgroup = "py-alienlife-items",
     order = "h"
 }:add_unlock("silicon-carbide")
 

--- a/prototypes/recipes/recipes.lua
+++ b/prototypes/recipes/recipes.lua
@@ -1351,7 +1351,7 @@ RECIPE {
         {type = "fluid", name = "syngas",    amount = 50},
     },
     main_product = "crude-oil",
-    subgroup = "py-alienlife-recipes",
+    subgroup = "py-alienlife-fluids",
     order = "a"
 }:add_unlock("biotech-mk03")
 

--- a/prototypes/recipes/rennea/recipes-rennea-megafarm.lua
+++ b/prototypes/recipes/rennea/recipes-rennea-megafarm.lua
@@ -4,6 +4,7 @@ RECIPE {
     type = "recipe",
     name = "rennea-super-1",
     category = "rennea-farm",
+    subgroup = "py-alienlife-rennea-smartfarm",
     enabled = false,
     energy_required = 100,
     ingredients = {
@@ -22,6 +23,7 @@ RECIPE {
     type = "recipe",
     name = "rennea-super-2",
     category = "rennea-farm",
+    subgroup = "py-alienlife-rennea-smartfarm",
     enabled = false,
     energy_required = 100,
     ingredients = {
@@ -41,6 +43,7 @@ RECIPE {
     type = "recipe",
     name = "rennea-super-3",
     category = "rennea-farm",
+    subgroup = "py-alienlife-rennea-smartfarm",
     enabled = false,
     energy_required = 100,
     ingredients = {
@@ -61,6 +64,7 @@ RECIPE {
     type = "recipe",
     name = "rennea-super-4",
     category = "rennea-farm",
+    subgroup = "py-alienlife-rennea-smartfarm",
     enabled = false,
     energy_required = 100,
     ingredients = {
@@ -81,6 +85,7 @@ RECIPE {
     type = "recipe",
     name = "rennea-super-5",
     category = "rennea-farm",
+    subgroup = "py-alienlife-rennea-smartfarm",
     enabled = false,
     energy_required = 100,
     ingredients = {
@@ -102,6 +107,7 @@ RECIPE {
     type = "recipe",
     name = "rennea-super-6",
     category = "rennea-farm",
+    subgroup = "py-alienlife-rennea-smartfarm",
     enabled = false,
     energy_required = 100,
     ingredients = {
@@ -123,6 +129,7 @@ RECIPE {
     type = "recipe",
     name = "rennea-super-7",
     category = "rennea-farm",
+    subgroup = "py-alienlife-rennea-smartfarm",
     enabled = false,
     energy_required = 100,
     ingredients = {
@@ -142,6 +149,7 @@ RECIPE {
     type = "recipe",
     name = "rennea-super-10",
     category = "rennea-farm",
+    subgroup = "py-alienlife-rennea-smartfarm",
     enabled = false,
     energy_required = 60,
     ingredients = {

--- a/prototypes/recipes/scrondrix/recipes-scrondrix-products.lua
+++ b/prototypes/recipes/scrondrix/recipes-scrondrix-products.lua
@@ -3,7 +3,7 @@
 py.autorecipes {
 	name = "Scrondrix-Manure",
 	category = "scrondrix",
-	subgroup = "py-alienlife-ulric",
+	subgroup = "py-alienlife-scrondrix",
 	order = "b",
 	main_product = "manure",
 	number_icons = true,

--- a/prototypes/recipes/scrondrix/recipes-scrondrix-products.lua
+++ b/prototypes/recipes/scrondrix/recipes-scrondrix-products.lua
@@ -3,6 +3,8 @@
 py.autorecipes {
 	name = "Scrondrix-Manure",
 	category = "scrondrix",
+	subgroup = "py-alienlife-ulric",
+	order = "b",
 	main_product = "manure",
 	number_icons = true,
 	mats =

--- a/prototypes/recipes/sea-sponge/recipes-sea-sponge.lua
+++ b/prototypes/recipes/sea-sponge/recipes-sea-sponge.lua
@@ -110,7 +110,7 @@ RECIPE {
     results = {
         {type = "item", name = "ore-quartz", amount = 10},
     },
-    subgroup = "py-alienlife-items",
+    subgroup = "py-alienlife-sponge",
     order = "c",
     icons = py.composite_icon("ore-quartz", "sea-sponge")
 }:add_unlock("water-invertebrates-mk01")
@@ -127,7 +127,7 @@ RECIPE {
     results = {
         {type = "item", name = "ore-quartz", amount = 7},
     },
-    subgroup = "py-alienlife-items",
+    subgroup = "py-alienlife-sponge",
     order = "c",
     icons = py.composite_icon("ore-quartz", "sea-sponge-sprouts")
 }:add_unlock("water-invertebrates-mk01")

--- a/prototypes/recipes/tuuphra/recipes-tuuphra-megafarm.lua
+++ b/prototypes/recipes/tuuphra/recipes-tuuphra-megafarm.lua
@@ -4,6 +4,7 @@ RECIPE {
     type = "recipe",
     name = "tuuphra-super-1",
     category = "tuuphra-farm",
+    subgroup = "py-alienlife-tuuphra-smartfarm",
     enabled = false,
     energy_required = 100,
     ingredients = {
@@ -21,6 +22,7 @@ RECIPE {
     type = "recipe",
     name = "tuuphra-super-2",
     category = "tuuphra-farm",
+    subgroup = "py-alienlife-tuuphra-smartfarm",
     enabled = false,
     energy_required = 100,
     ingredients = {
@@ -39,6 +41,7 @@ RECIPE {
     type = "recipe",
     name = "tuuphra-super-3",
     category = "tuuphra-farm",
+    subgroup = "py-alienlife-tuuphra-smartfarm",
     enabled = false,
     energy_required = 100,
     ingredients = {
@@ -58,6 +61,7 @@ RECIPE {
     type = "recipe",
     name = "tuuphra-super-4",
     category = "tuuphra-farm",
+    subgroup = "py-alienlife-tuuphra-smartfarm",
     enabled = false,
     energy_required = 100,
     ingredients = {
@@ -78,6 +82,7 @@ RECIPE {
     type = "recipe",
     name = "tuuphra-super-5",
     category = "tuuphra-farm",
+    subgroup = "py-alienlife-tuuphra-smartfarm",
     enabled = false,
     energy_required = 100,
     ingredients = {
@@ -98,6 +103,7 @@ RECIPE {
     type = "recipe",
     name = "tuuphra-super-6",
     category = "tuuphra-farm",
+    subgroup = "py-alienlife-tuuphra-smartfarm",
     enabled = false,
     energy_required = 100,
     ingredients = {
@@ -119,6 +125,7 @@ RECIPE {
     type = "recipe",
     name = "tuuphra-super-7",
     category = "tuuphra-farm",
+    subgroup = "py-alienlife-tuuphra-smartfarm",
     enabled = false,
     energy_required = 100,
     ingredients = {
@@ -139,6 +146,7 @@ RECIPE {
     type = "recipe",
     name = "tuuphra-super-10",
     category = "tuuphra-farm",
+    subgroup = "py-alienlife-tuuphra-smartfarm",
     enabled = false,
     energy_required = 60,
     ingredients = {

--- a/prototypes/recipes/yotoi/recipes-yotoi-megafarm.lua
+++ b/prototypes/recipes/yotoi/recipes-yotoi-megafarm.lua
@@ -4,6 +4,7 @@ RECIPE {
     type = "recipe",
     name = "yotoi-super-1",
     category = "yotoi-farm",
+    subgroup = "py-alienlife-yotoi-smartfarm",
     enabled = false,
     energy_required = 100,
     ingredients = {
@@ -20,6 +21,7 @@ RECIPE {
     type = "recipe",
     name = "yotoi-super-2",
     category = "yotoi-farm",
+    subgroup = "py-alienlife-yotoi-smartfarm",
     enabled = false,
     energy_required = 100,
     ingredients = {
@@ -37,6 +39,7 @@ RECIPE {
     type = "recipe",
     name = "yotoi-super-3",
     category = "yotoi-farm",
+    subgroup = "py-alienlife-yotoi-smartfarm",
     enabled = false,
     energy_required = 100,
     ingredients = {
@@ -55,6 +58,7 @@ RECIPE {
     type = "recipe",
     name = "yotoi-super-4",
     category = "yotoi-farm",
+    subgroup = "py-alienlife-yotoi-smartfarm",
     enabled = false,
     energy_required = 100,
     ingredients = {
@@ -73,6 +77,7 @@ RECIPE {
     type = "recipe",
     name = "yotoi-super-5",
     category = "yotoi-farm",
+    subgroup = "py-alienlife-yotoi-smartfarm",
     enabled = false,
     energy_required = 100,
     ingredients = {
@@ -92,6 +97,7 @@ RECIPE {
     type = "recipe",
     name = "yotoi-super-6",
     category = "yotoi-farm",
+    subgroup = "py-alienlife-yotoi-smartfarm",
     enabled = false,
     energy_required = 100,
     ingredients = {
@@ -112,6 +118,7 @@ RECIPE {
     type = "recipe",
     name = "yotoi-super-7",
     category = "yotoi-farm",
+    subgroup = "py-alienlife-yotoi-smartfarm",
     enabled = false,
     energy_required = 100,
     ingredients = {
@@ -133,6 +140,7 @@ RECIPE {
     type = "recipe",
     name = "yotoi-super-8",
     category = "yotoi-farm",
+    subgroup = "py-alienlife-yotoi-smartfarm",
     enabled = false,
     energy_required = 100,
     ingredients = {
@@ -155,6 +163,7 @@ RECIPE {
     type = "recipe",
     name = "yotoi-super-10",
     category = "yotoi-farm",
+    subgroup = "py-alienlife-yotoi-smartfarm",
     enabled = false,
     energy_required = 60,
     ingredients = {

--- a/prototypes/updates/pycoalprocessing-updates.lua
+++ b/prototypes/updates/pycoalprocessing-updates.lua
@@ -93,8 +93,8 @@ RECIPE("log3"):add_ingredient {type = "item", name = "wood-seedling", amount = 3
 RECIPE("log4"):add_ingredient {type = "item", name = "wood-seedling", amount = 3}:subgroup_order("py-alienlife-plants", "a").category = "fwf"
 RECIPE("log5"):add_ingredient {type = "item", name = "wood-seedling", amount = 3}:subgroup_order("py-alienlife-plants", "a").category = "fwf"
 RECIPE("log6"):add_ingredient {type = "item", name = "wood-seedling", amount = 3}:subgroup_order("py-alienlife-plants", "a").category = "fwf"
-RECIPE("log-wood"):subgroup_order("py-alienlife-recipes", "a")
-RECIPE("fawogae-substrate"):remove_ingredient("fawogae"):add_ingredient {type = "item", name = "petri-dish-bacteria", amount = 2}:add_ingredient {type = "item", name = "cellulose", amount = 3}:replace_ingredient("coke", "moss"):subgroup_order("py-alienlife-recipes", "a")
+RECIPE("log-wood"):subgroup_order("py-alienlife-plants", "a").category = "fwf"
+RECIPE("fawogae-substrate"):remove_ingredient("fawogae"):add_ingredient {type = "item", name = "petri-dish-bacteria", amount = 2}:add_ingredient {type = "item", name = "cellulose", amount = 3}:replace_ingredient("coke", "moss"):subgroup_order("py-alienlife-items", "a")
 RECIPE("bio-sample01"):add_ingredient {type = "item", name = "petri-dish-bacteria", amount = 2}:add_ingredient {type = "item", name = "native-flora", amount = 12}
 RECIPE("fawogae-substrate"):add_unlock("basic-substrate").enabled = false
 

--- a/prototypes/updates/pycoalprocessing-updates.lua
+++ b/prototypes/updates/pycoalprocessing-updates.lua
@@ -82,9 +82,9 @@ RECIPE("automated-factory-mk01"):replace_ingredient("fast-inserter", "inserter")
 -----RECIPES-----
 FLUID("carbon-dioxide"):subgroup_order("py-alienlife-items", "a")
 ITEM("ralesia-seeds"):subgroup_order("py-alienlife-ralesia", "a")
-ITEM("bonemeal"):subgroup_order("py-alienlife-items", "a")
+ITEM("bonemeal"):subgroup_order("py-alienlife-creature-product", "a")
 ITEM("organics"):subgroup_order("py-alienlife-items", "a")
-ITEM("mukmoux-fat"):subgroup_order("py-alienlife-items", "a")
+ITEM("mukmoux-fat"):subgroup_order("py-alienlife-creature-product", "a")
 ITEM("fawogae-substrate"):subgroup_order("py-alienlife-items", "a")
 RECIPE("fawogae"):set_fields {enabled = false}
 RECIPE("log1"):add_ingredient {type = "item", name = "wood-seedling", amount = 3}:subgroup_order("py-alienlife-plants", "a").category = "fwf"

--- a/prototypes/updates/pyhightech-updates.lua
+++ b/prototypes/updates/pyhightech-updates.lua
@@ -435,8 +435,8 @@ RECIPE("fawogae2"):remove_unlock("advanced-circuit")
 --RECIPE('urea').category = 'vrauks'):subgroup_order('py-alienlife-auog', 'a'
 ITEM("urea"):subgroup_order("py-alienlife-auog", "a")
 ITEM("mosfet"):subgroup_order("py-hightech-tier-2", "f")
-RECIPE("waste-water-urea"):subgroup_order("py-alienlife-recipes", "a"):remove_unlock("fluid-separation"):add_unlock("water-invertebrates-mk01")
-RECIPE("ammonia-urea"):subgroup_order("py-alienlife-recipes", "a"):remove_unlock("basic-electronics"):add_unlock("biotech-mk02")
+RECIPE("waste-water-urea"):subgroup_order("py-alienlife-items", "a"):remove_unlock("fluid-separation"):add_unlock("water-invertebrates-mk01")
+RECIPE("ammonia-urea"):subgroup_order("py-hightech-fluids", "a1"):remove_unlock("basic-electronics"):add_unlock("biotech-mk02")
 RECIPE("urea2"):remove_unlock("auog-2"):set_fields {hidden = true}
 RECIPE("urea"):set_fields {enabled = false}
 RECIPE("mukmoux-fat2"):remove_unlock("advanced-circuit"):set_fields {hidden = true}

--- a/prototypes/updates/pyhightech-updates.lua
+++ b/prototypes/updates/pyhightech-updates.lua
@@ -763,6 +763,7 @@ RECIPE {
     type = "recipe",
     name = "ralesia-super-8",
     category = "ralesia-farm",
+    subgroup = "py-alienlife-ralesia-smartfarm",
     enabled = false,
     energy_required = 80,
     ingredients = {
@@ -782,6 +783,7 @@ RECIPE {
     type = "recipe",
     name = "ralesia-super-9",
     category = "ralesia-farm",
+    subgroup = "py-alienlife-ralesia-smartfarm",
     enabled = false,
     energy_required = 80,
     ingredients = {
@@ -804,6 +806,7 @@ RECIPE {
     type = "recipe",
     name = "rennea-super-8",
     category = "rennea-farm",
+    subgroup = "py-alienlife-rennea-smartfarm",
     enabled = false,
     energy_required = 100,
     ingredients = {
@@ -823,6 +826,7 @@ RECIPE {
     type = "recipe",
     name = "rennea-super-9",
     category = "rennea-farm",
+    subgroup = "py-alienlife-rennea-smartfarm",
     enabled = false,
     energy_required = 100,
     ingredients = {
@@ -845,6 +849,7 @@ RECIPE {
     type = "recipe",
     name = "tuuphra-super-8",
     category = "tuuphra-farm",
+    subgroup = "py-alienlife-tuuphra-smartfarm",
     enabled = false,
     energy_required = 100,
     ingredients = {
@@ -865,6 +870,7 @@ RECIPE {
     type = "recipe",
     name = "tuuphra-super-9",
     category = "tuuphra-farm",
+    subgroup = "py-alienlife-tuuphra-smartfarm",
     enabled = false,
     energy_required = 100,
     ingredients = {
@@ -888,6 +894,7 @@ RECIPE {
     type = "recipe",
     name = "grod-super-9",
     category = "grod-farm",
+    subgroup = "py-alienlife-grod-smartfarm",
     enabled = false,
     energy_required = 100,
     ingredients = {
@@ -911,6 +918,7 @@ RECIPE {
     type = "recipe",
     name = "yotoi-super-9",
     category = "yotoi-farm",
+    subgroup = "py-alienlife-yotoi-smartfarm",
     enabled = false,
     energy_required = 100,
     ingredients = {


### PR DESCRIPTION
I have reorganized many alienlife items into categories to their better fitting places.
i have made sure new subgroups are fitting and necessary and dont increase the length of the alienlife tab, pretty sure it even decreases it.
**all changes:**

vatbrain and cartriges moved into production tab right under beacons
fertilizer moved into own new subgroup

py-alienlife-items split into -items, -anorganics, -creature-product
cottongut-science recipes put into same group as their items (py-alienlife-science)

fawagoe spores moved to fawagoe-group
bhoddos spores moved to bhoddos-group
fish eggs moved to fish-group
scrondrix manure moved to scrondrix-group

smart-farm recipes have now a group each below their plant-groups
      that inclues native flora moved from items to -native-flora-smartfarm group

the 2 sea-sponge groups are now 1 and their processing recipes moved from item to the group
xenogenic cells have their own group
psc and chelator have their own group
nitrogen-mustard and nitrous-oxide moved from fluids to gases

removed the recipe-subgroup as its contend fitted better into other groups:
    vrauk cocoon items moved into vrauks group
    manure-to-crude moved into fluids group
    fawagoe-substrate (basis-substrate) moved into items group
    log-wood moved into plants/fwf category
    waste-water-urea moved into items group
    ammonia from urea moved to other ammonia recipes in pyhightech-fluids group

**some notes:**
cottongut-science recipes in creature-products group would fit nicely, as py-alienlife-science now has its own line but wasnt sure.
all mounts feel a bit off in their recpective tiers as all others are machines, putting them into buildings-others or -special-creatures would remove 4 basically empty lines.

attatched are pictures of the main changes
after:
<img width="310" height="294" alt="Screenshot 2026-02-26 123531" src="https://github.com/user-attachments/assets/5961483f-cb24-4ed2-8dab-dc3ab62feb5c" />
<img width="316" height="777" alt="Screenshot 2026-02-26 123514" src="https://github.com/user-attachments/assets/2077db00-87a6-49c7-ad4d-2b5bf19da775" />
before:
<img width="313" height="339" alt="Screenshot 2026-02-26 125919" src="https://github.com/user-attachments/assets/3a2323d8-b351-43ad-8ece-7678ac459920" />
<img width="315" height="783" alt="Screenshot 2026-02-26 125903" src="https://github.com/user-attachments/assets/ca1a4c51-8f7c-4730-8665-861e91dbb219" />

