### PR TITLE
Fix priority order for pipette on caravan food slots

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -3,6 +3,7 @@ Version: 3.0.64
 Date: ???
   Changes:
     - Fixed failure migrating certain fluid caravan interrupts
+    - Fixed pipette food selection on caravan food slots having incorrect priority
 ---------------------------------------------------------------------------------------------------
 Version: 3.0.63
 Date: 2026-03-28

--- a/scripts/caravan/gui/inventories.lua
+++ b/scripts/caravan/gui/inventories.lua
@@ -429,14 +429,16 @@ py.on_event("py_caravan_pipette", function(event)
             set_stack_to_cursor(player, main_inventory, index, function(s) return s end)
         end
     else -- otherwise find the most valuable food in the player inventory and put it into the cursor
-        local sorted_foods = table.deepcopy(caravan_prototypes[caravan_data.entity.name].favorite_foods)
-        table.sort(sorted_foods, function(a, b) return a > b end)
-        for food_name in pairs(sorted_foods) do
-            local _, index = main_inventory.find_item_stack(food_name)
-            if index then
-                set_stack_to_cursor(player, main_inventory, index, function(s) return s end)
-                break
+        local best_slot, best_value = nil, 0
+        for food_name, food_value in pairs(caravan_prototypes[caravan_data.entity.name].favorite_foods) do
+            local _, new_slot = main_inventory.find_item_stack(food_name)
+            if new_slot and food_value > best_value then
+                best_slot = new_slot
+                best_value = food_value
             end
+        end
+        if best_value > 0 then
+            set_stack_to_cursor(player, main_inventory, best_slot, function(s) return s end)
         end
     end
 end)


### PR DESCRIPTION
table.sort doesn't work on non-arrays, oopsie