### PR TITLE
Fix caravan GUI crash in multiplayer by keying gui_elements_by_name per player

### DIFF
--- a/migrations/3.0.64.lua
+++ b/migrations/3.0.64.lua
@@ -1,0 +1,1 @@
+storage.gui_elements_by_name = {}

--- a/scripts/caravan/gui.lua
+++ b/scripts/caravan/gui.lua
@@ -149,7 +149,8 @@ py.on_event(defines.events.on_gui_closed, function(event)
         if slider_frame then
             slider_frame.destroy()
         elseif add_interrupt_frame then
-            local btn = storage.gui_elements_by_name["py_caravan_add_interrupt_search_button"]
+            local player_elems = storage.gui_elements_by_name[player.index]
+            local btn = player_elems and player_elems["py_caravan_add_interrupt_search_button"]
             if btn and btn.toggled then
                 AddInterruptGui.toggle_search_button(player)
             else

--- a/scripts/caravan/gui/add_interrupt.lua
+++ b/scripts/caravan/gui/add_interrupt.lua
@@ -15,7 +15,7 @@ function P.build_main_frame(parent, fallback_location)
     return frame
 end
 
-function P.build_title_bar_flow(parent, tags)
+function P.build_title_bar_flow(parent, player, tags)
     local flow = parent.add {type = "flow", name = "title_bar_flow", direction = "horizontal", style = "frame_header_flow"}
 
     flow.add {type = "label", caption = {"caravan-gui.add-interrupt-frame-title"}, style = "frame_title"}
@@ -30,7 +30,9 @@ function P.build_title_bar_flow(parent, tags)
     local search_button = flow.add {type = "sprite-button", name = "py_caravan_add_interrupt_search_button", style = "frame_action_button", sprite = "utility/search", tags = tags}
     flow.add {type = "sprite-button", name = "py_caravan_add_interrupt_close_button", style = "close_button", sprite = "utility/close", tags = tags}
 
-    storage.gui_elements_by_name[search_button.name] = search_button
+    local elems = storage.gui_elements_by_name
+    elems[player.index] = elems[player.index] or {}
+    elems[player.index][search_button.name] = search_button
     return flow
 end
 
@@ -83,15 +85,16 @@ function P.build_interrupt_list(parent, caravan_data, interrupts, tags)
 end
 
 ---@param parent LuaGuiElement
+---@param player LuaPlayer
 ---@param caravan_data table
 ---@param cursor_location GuiLocation?
 ---@return LuaGuiElement
-function P.build(parent, caravan_data, cursor_location)
+function P.build(parent, player, caravan_data, cursor_location)
     local tags = {unit_number = caravan_data.unit_number}
 
     local main_frame = P.build_main_frame(parent, cursor_location)
 
-    P.build_title_bar_flow(main_frame, tags)
+    P.build_title_bar_flow(main_frame, player, tags)
 
     local contents_frame = main_frame.add {type = "frame", name = "contents_frame", style = "inside_deep_frame", direction = "vertical", tags = tags}
     P.build_text_input(contents_frame, tags)

--- a/scripts/caravan/gui/cargo_tab.lua
+++ b/scripts/caravan/gui/cargo_tab.lua
@@ -58,7 +58,7 @@ function P.build_cargo_flow(parent, player, caravan_data, enabled)
     local flow = parent.add {type = "flow", direction = "vertical", name = "cargo_flow", enabled = enabled}
     flow.style.vertical_spacing = 8
     flow.add {type = "label", caption = "Food"}
-    inv.build_fuel_inventory(flow, caravan_data)
+    inv.build_fuel_inventory(flow, player, caravan_data)
     flow.add {type = "line", style = "inside_shallow_frame_with_padding_line"}.style.horizontally_stretchable = true
 
     if caravan_data.entity.name:find("^fluidavan") or caravan_data.entity.name:find("^fluidflyavan")then
@@ -66,7 +66,7 @@ function P.build_cargo_flow(parent, player, caravan_data, enabled)
         P.build_fluid_flow(flow, caravan_data)
     else
         flow.add {type = "label", caption = {"entity-name.caravan"}}
-        inv.build_caravan_inventory(flow, caravan_data)
+        inv.build_caravan_inventory(flow, player, caravan_data)
     end
     flow.add {type = "line", style = "inside_shallow_frame_with_padding_line"}.style.horizontally_stretchable = true
     flow.add {type = "label", caption = "Character"}

--- a/scripts/caravan/gui/inventories.lua
+++ b/scripts/caravan/gui/inventories.lua
@@ -96,7 +96,7 @@ local function build_inventory_table(parent, inventory, name, tags, default_empt
     return inventory_table
 end
 
-local function build_inventory_flow(parent, inventory, name, tags, default_empty_slot)
+local function build_inventory_flow(parent, player, inventory, name, tags, default_empty_slot)
     local flow = parent.add {type = "flow", style = "packed_horizontal_flow", tags = tags}
     flow.style.vertical_align = "center"
     flow.style.horizontal_spacing = 10
@@ -108,14 +108,16 @@ local function build_inventory_flow(parent, inventory, name, tags, default_empty
 
     build_inventory_table(pane, inventory, name, tags, default_empty_slot)
 
-    storage.gui_elements_by_name[name] = flow
+    local elems = storage.gui_elements_by_name
+    elems[player.index] = elems[player.index] or {}
+    elems[player.index][name] = flow
     return flow
 end
 
-local function build_fuel_inventory_flow(parent, caravan_data, fuel_inventory, name, tags)
+local function build_fuel_inventory_flow(parent, player, caravan_data, fuel_inventory, name, tags)
     local favorite_food_tooltip = py.generate_favorite_food_tooltip(caravan_prototypes[caravan_data.entity.name].favorite_foods, "caravan-gui")
 
-    local flow = build_inventory_flow(parent, fuel_inventory, name, tags, {sprite = "slot_icon_food", tooltip = favorite_food_tooltip})
+    local flow = build_inventory_flow(parent, player, fuel_inventory, name, tags, {sprite = "slot_icon_food", tooltip = favorite_food_tooltip})
     local bar = flow.add {type = "progressbar", style = "burning_progressbar"}
     bar.value = caravan_data.fuel_bar / caravan_data.last_eaten_fuel_value
     bar.style.horizontally_stretchable = true
@@ -135,49 +137,55 @@ function P.build_character_inventory(parent, player, caravan_data)
 
     local name = "py_caravan_player_inventory"
     local inventory_frame = parent.add {type = "frame", style = "inventory_frame", enabled = parent.enabled}
-    build_inventory_flow(inventory_frame, inventory, name, {unit_number = caravan_data.unit_number})
+    build_inventory_flow(inventory_frame, player, inventory, name, {unit_number = caravan_data.unit_number})
 end
 
-function P.build_caravan_inventory(parent, caravan_data)
+function P.build_caravan_inventory(parent, player, caravan_data)
     local name = "py_caravan_caravan_inventory"
     local inventory_frame = parent.add {type = "frame", style = "inventory_frame", enabled = parent.enabled}
-    build_inventory_flow(inventory_frame, caravan_data.inventory, name, {unit_number = caravan_data.unit_number})
+    build_inventory_flow(inventory_frame, player, caravan_data.inventory, name, {unit_number = caravan_data.unit_number})
 end
 
-function P.build_fuel_inventory(parent, caravan_data)
+function P.build_fuel_inventory(parent, player, caravan_data)
     local name = "py_caravan_fuel_inventory"
     local inventory_frame = parent.add {type = "frame", style = "inventory_frame", enabled = parent.enabled}
-    build_fuel_inventory_flow(inventory_frame, caravan_data, caravan_data.fuel_inventory, name, {unit_number = caravan_data.unit_number})
+    build_fuel_inventory_flow(inventory_frame, player, caravan_data, caravan_data.fuel_inventory, name, {unit_number = caravan_data.unit_number})
 end
 
 function P.update_character_inventory(player, caravan_data)
     local name = "py_caravan_player_inventory"
-    local elem = storage.gui_elements_by_name[name]
+    local player_elems = storage.gui_elements_by_name[player.index]
+    local elem = player_elems and player_elems[name]
+    if not elem or not elem.valid then return end
     local parent = elem.parent
     elem.destroy()
 
     local inventory = get_inventory(player)
     inventory.sort_and_merge()
 
-    build_inventory_flow(parent, inventory, name, {unit_number = caravan_data.unit_number})
+    build_inventory_flow(parent, player, inventory, name, {unit_number = caravan_data.unit_number})
 end
 
 function P.update_caravan_inventory(player, caravan_data)
     local name = "py_caravan_caravan_inventory"
-    local elem = storage.gui_elements_by_name[name]
+    local player_elems = storage.gui_elements_by_name[player.index]
+    local elem = player_elems and player_elems[name]
+    if not elem or not elem.valid then return end
     local parent = elem.parent
     elem.destroy()
 
-    build_inventory_flow(parent, caravan_data.inventory, name, {unit_number = caravan_data.unit_number})
+    build_inventory_flow(parent, player, caravan_data.inventory, name, {unit_number = caravan_data.unit_number})
 end
 
 function P.update_fuel_inventory(player, caravan_data)
     local name = "py_caravan_fuel_inventory"
-    local elem = storage.gui_elements_by_name[name]
+    local player_elems = storage.gui_elements_by_name[player.index]
+    local elem = player_elems and player_elems[name]
+    if not elem or not elem.valid then return end
     local parent = elem.parent
     elem.destroy()
 
-    build_fuel_inventory_flow(parent, caravan_data, caravan_data.fuel_inventory, name, {unit_number = caravan_data.unit_number})
+    build_fuel_inventory_flow(parent, player, caravan_data, caravan_data.fuel_inventory, name, {unit_number = caravan_data.unit_number})
 end
 
 local function is_character_inventory(inventory)

--- a/scripts/caravan/gui/schedule_tab.lua
+++ b/scripts/caravan/gui/schedule_tab.lua
@@ -166,7 +166,7 @@ gui_events[defines.events.on_gui_click]["py_caravan_interrupt_add_button"] = fun
     if player.gui.screen.add_interrupt_gui then
         player.gui.screen.add_interrupt_gui.destroy()
     end
-    local add_interrupt_frame = AddInterruptGui.build(player.gui.screen, caravan_data, event.cursor_display_location)
+    local add_interrupt_frame = AddInterruptGui.build(player.gui.screen, player, caravan_data, event.cursor_display_location)
 end
 
 gui_events[defines.events.on_gui_click]["py_caravan_interrupt_edit_button"] = function(event)


### PR DESCRIPTION
Tested in a multiplayer game, making sure we could both see and update caravan fuel and inventory at the same time, both on different and the same caravans.

storage.gui_elements_by_name was a flat dict keyed only by element name, so opening the caravan GUI as a second player overwrote the first player''s stored elements. Any inventory change for the first player then accessed a destroyed element and crashed all clients.

Key every read and write by player.index (lazy sub-table init at the write site). Add validity guards in all three update_* functions before .parent access. Add migration 3.0.64 to wipe the old flat structure on existing saves.