### PR TITLE
Farm speed 2.0 restoration

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -1,4 +1,9 @@
 ---------------------------------------------------------------------------------------------------
+Version: 3.1.4
+Date: ???
+  Changes:
+    - Adjust farm speed computation to match 2.0 speeds for some buildings. Resolves https://github.com/pyanodon/pybugreports/issues/1525
+---------------------------------------------------------------------------------------------------
 Version: 3.1.3
 Date: ???
   Changes:

--- a/prototypes/buildings/cridren-enclosure-mk02.lua
+++ b/prototypes/buildings/cridren-enclosure-mk02.lua
@@ -47,7 +47,8 @@ ENTITY {
     allowed_effects = {"speed", "productivity", "consumption", "pollution", "quality"},
     crafting_categories = {"cridren"},
     effect_receiver = {base_effect = {speed = -1}, speed_limits = {low = -0.9999}},
-    crafting_speed = py.farm_speed_derived(MODULE_SLOTS, "cridren-enclosure-mk01"),
+    crafting_speed = py.farm_speed_derived(MODULE_SLOTS, "cridren-enclosure-mk01") * py.farm_speed_correction20_wrong_modules(
+                            MODULE_SLOTS, "cridren-enclosure-mk01", 1, 1),
     energy_source = {
         type = "electric",
         usage_priority = "secondary-input",

--- a/prototypes/buildings/cridren-enclosure-mk03.lua
+++ b/prototypes/buildings/cridren-enclosure-mk03.lua
@@ -47,7 +47,8 @@ ENTITY {
     allowed_effects = {"speed", "productivity", "consumption", "pollution", "quality"},
     crafting_categories = {"cridren"},
     effect_receiver = {base_effect = {speed = -1}, speed_limits = {low = -0.9999}},
-    crafting_speed = py.farm_speed_derived(MODULE_SLOTS, "cridren-enclosure-mk01"),
+    crafting_speed = py.farm_speed_derived(MODULE_SLOTS, "cridren-enclosure-mk01") * py.farm_speed_correction20_wrong_modules(
+                            MODULE_SLOTS, "cridren-enclosure-mk01", 1, 1),
     energy_source = {
         type = "electric",
         usage_priority = "secondary-input",

--- a/prototypes/buildings/cridren-enclosure-mk04.lua
+++ b/prototypes/buildings/cridren-enclosure-mk04.lua
@@ -47,7 +47,8 @@ ENTITY {
     allowed_effects = {"speed", "productivity", "consumption", "pollution", "quality"},
     crafting_categories = {"cridren"},
     effect_receiver = {base_effect = {speed = -1}, speed_limits = {low = -0.9999}},
-    crafting_speed = py.farm_speed_derived(MODULE_SLOTS, "cridren-enclosure-mk01"),
+    crafting_speed = py.farm_speed_derived(MODULE_SLOTS, "cridren-enclosure-mk01") * py.farm_speed_correction20_wrong_modules(
+                            MODULE_SLOTS, "cridren-enclosure-mk01", 1, 1),
     energy_source = {
         type = "electric",
         usage_priority = "secondary-input",

--- a/prototypes/buildings/dhilmos-pool-mk02.lua
+++ b/prototypes/buildings/dhilmos-pool-mk02.lua
@@ -51,7 +51,8 @@ ENTITY {
     allowed_effects = {"speed", "productivity", "consumption", "pollution", "quality"},
     crafting_categories = {"dhilmos"},
     effect_receiver = {base_effect = {speed = -1}, speed_limits = {low = -0.9999}},
-    crafting_speed = py.farm_speed_derived(MODULE_SLOTS, "dhilmos-pool-mk01"),
+    crafting_speed = py.farm_speed_derived(MODULE_SLOTS, "dhilmos-pool-mk01") * py.farm_speed_correction20_wrong_modules(
+                            MODULE_SLOTS, "dhilmos-pool-mk01", 1, 1.5),
     energy_source = {
         type = "electric",
         usage_priority = "secondary-input",

--- a/prototypes/buildings/dhilmos-pool-mk03.lua
+++ b/prototypes/buildings/dhilmos-pool-mk03.lua
@@ -48,7 +48,8 @@ ENTITY {
     allowed_effects = {"speed", "productivity", "consumption", "pollution", "quality"},
     crafting_categories = {"dhilmos"},
     effect_receiver = {base_effect = {speed = -1}, speed_limits = {low = -0.9999}},
-    crafting_speed = py.farm_speed_derived(MODULE_SLOTS, "dhilmos-pool-mk01"),
+    crafting_speed = py.farm_speed_derived(MODULE_SLOTS, "dhilmos-pool-mk01") * py.farm_speed_correction20_wrong_modules(
+                            MODULE_SLOTS, "dhilmos-pool-mk01", 1, 2),
     energy_source = {
         type = "electric",
         usage_priority = "secondary-input",

--- a/prototypes/buildings/dhilmos-pool-mk04.lua
+++ b/prototypes/buildings/dhilmos-pool-mk04.lua
@@ -47,7 +47,8 @@ ENTITY {
     allowed_effects = {"speed", "productivity", "consumption", "pollution", "quality"},
     crafting_categories = {"dhilmos"},
     effect_receiver = {base_effect = {speed = -1}, speed_limits = {low = -0.9999}},
-    crafting_speed = py.farm_speed_derived(MODULE_SLOTS, "dhilmos-pool-mk01"),
+    crafting_speed = py.farm_speed_derived(MODULE_SLOTS, "dhilmos-pool-mk01") * py.farm_speed_correction20_wrong_modules(
+                            MODULE_SLOTS, "dhilmos-pool-mk01", 1, 2.5),
     energy_source = {
         type = "electric",
         usage_priority = "secondary-input",

--- a/prototypes/buildings/ez-ranch-mk02.lua
+++ b/prototypes/buildings/ez-ranch-mk02.lua
@@ -49,7 +49,8 @@ ENTITY {
     allowed_effects = {"speed", "productivity", "consumption", "pollution", "quality"},
     crafting_categories = {"korlex"},
     effect_receiver = {base_effect = {speed = -1}, speed_limits = {low = -0.9999}},
-    crafting_speed = py.farm_speed_derived(MODULE_SLOTS, "ez-ranch-mk01"),
+    crafting_speed = py.farm_speed_derived(MODULE_SLOTS, "ez-ranch-mk01") * py.farm_speed_correction20_wrong_modules(
+                            MODULE_SLOTS, "ez-ranch-mk01", 1, 1.25),
     energy_source = {
         type = "electric",
         usage_priority = "secondary-input",

--- a/prototypes/buildings/ez-ranch-mk03.lua
+++ b/prototypes/buildings/ez-ranch-mk03.lua
@@ -49,7 +49,8 @@ ENTITY {
     allowed_effects = {"speed", "productivity", "consumption", "pollution", "quality"},
     crafting_categories = {"korlex"},
     effect_receiver = {base_effect = {speed = -1}, speed_limits = {low = -0.9999}},
-    crafting_speed = py.farm_speed_derived(MODULE_SLOTS, "ez-ranch-mk01"),
+    crafting_speed = py.farm_speed_derived(MODULE_SLOTS, "ez-ranch-mk01") * py.farm_speed_correction20_wrong_modules(
+                            MODULE_SLOTS, "ez-ranch-mk01", 1, 1.5),
     energy_source = {
         type = "electric",
         usage_priority = "secondary-input",

--- a/prototypes/buildings/ez-ranch-mk04.lua
+++ b/prototypes/buildings/ez-ranch-mk04.lua
@@ -48,7 +48,8 @@ ENTITY {
     allowed_effects = {"speed", "productivity", "consumption", "pollution", "quality"},
     crafting_categories = {"korlex"},
     effect_receiver = {base_effect = {speed = -1}, speed_limits = {low = -0.9999}},
-    crafting_speed = py.farm_speed_derived(MODULE_SLOTS, "ez-ranch-mk01"),
+    crafting_speed = py.farm_speed_derived(MODULE_SLOTS, "ez-ranch-mk01") * py.farm_speed_correction20_wrong_modules(
+                            MODULE_SLOTS, "ez-ranch-mk01", 1, 2),
     energy_source = {
         type = "electric",
         usage_priority = "secondary-input",

--- a/prototypes/buildings/fish-farm.lua
+++ b/prototypes/buildings/fish-farm.lua
@@ -115,7 +115,7 @@ for i = 1, 4 do
         allowed_effects = {"speed", "productivity", "consumption", "pollution", "quality"},
         crafting_categories = {"fish-farm"},
         effect_receiver = {base_effect = {speed = -1}, speed_limits = {low = -0.9999}},
-        crafting_speed = (i == 1) and py.farm_speed(MODULE_SLOTS, FULL_CRAFTING_SPEED) or py.farm_speed_derived(MODULE_SLOTS, "fish-farm-mk01"),
+        crafting_speed = (i == 1) and py.farm_speed(MODULE_SLOTS, FULL_CRAFTING_SPEED) or py.farm_speed_derived(MODULE_SLOTS, "fish-farm-mk01") * py.farm_speed_correction20_wrong_modules(MODULE_SLOTS, "fish-farm-mk01", 1, 1 + 0.5*(i-1)),
         energy_source = {
             type = "electric",
             usage_priority = "secondary-input",

--- a/prototypes/buildings/mukmoux-pasture-mk02.lua
+++ b/prototypes/buildings/mukmoux-pasture-mk02.lua
@@ -46,7 +46,8 @@ ENTITY {
     allowed_effects = {"speed", "productivity", "consumption", "pollution", "quality"},
     crafting_categories = {"mukmoux"},
     effect_receiver = {base_effect = {speed = -1}, speed_limits = {low = -0.9999}},
-    crafting_speed = py.farm_speed_derived(MODULE_SLOTS, "mukmoux-pasture-mk01"),
+    crafting_speed = py.farm_speed_derived(MODULE_SLOTS, "mukmoux-pasture-mk01") * py.farm_speed_correction20_wrong_modules(
+                            MODULE_SLOTS, "mukmoux-pasture-mk01", 1, 1.5),
     energy_source = {
         type = "electric",
         usage_priority = "secondary-input",

--- a/prototypes/buildings/mukmoux-pasture-mk03.lua
+++ b/prototypes/buildings/mukmoux-pasture-mk03.lua
@@ -46,7 +46,8 @@ ENTITY {
     allowed_effects = {"speed", "productivity", "consumption", "pollution", "quality"},
     crafting_categories = {"mukmoux"},
     effect_receiver = {base_effect = {speed = -1}, speed_limits = {low = -0.9999}},
-    crafting_speed = py.farm_speed_derived(MODULE_SLOTS, "mukmoux-pasture-mk01"),
+    crafting_speed = py.farm_speed_derived(MODULE_SLOTS, "mukmoux-pasture-mk01") * py.farm_speed_correction20_wrong_modules(
+                            MODULE_SLOTS, "mukmoux-pasture-mk01", 1, 2),
     energy_source = {
         type = "electric",
         usage_priority = "secondary-input",

--- a/prototypes/buildings/mukmoux-pasture-mk04.lua
+++ b/prototypes/buildings/mukmoux-pasture-mk04.lua
@@ -46,7 +46,8 @@ ENTITY {
     allowed_effects = {"speed", "productivity", "consumption", "pollution", "quality"},
     crafting_categories = {"mukmoux"},
     effect_receiver = {base_effect = {speed = -1}, speed_limits = {low = -0.9999}},
-    crafting_speed = py.farm_speed_derived(MODULE_SLOTS, "mukmoux-pasture-mk01"),
+    crafting_speed = py.farm_speed_derived(MODULE_SLOTS, "mukmoux-pasture-mk01") * py.farm_speed_correction20_wrong_modules(
+                            MODULE_SLOTS, "mukmoux-pasture-mk01", 1, 2.5),
     energy_source = {
         type = "electric",
         usage_priority = "secondary-input",

--- a/prototypes/buildings/phadai-enclosure-mk02.lua
+++ b/prototypes/buildings/phadai-enclosure-mk02.lua
@@ -48,7 +48,8 @@ ENTITY {
     allowed_effects = {"speed", "productivity", "consumption", "pollution", "quality"},
     crafting_categories = {"phadai"},
     effect_receiver = {base_effect = {speed = -1}, speed_limits = {low = -0.9999}},
-    crafting_speed = py.farm_speed_derived(MODULE_SLOTS, "phadai-enclosure-mk01"),
+    crafting_speed = py.farm_speed_derived(MODULE_SLOTS, "phadai-enclosure-mk01") * py.farm_speed_correction20_wrong_modules(
+                            MODULE_SLOTS, "phadai-enclosure-mk01", 1, 1.25),
     energy_source = {
         type = "electric",
         usage_priority = "secondary-input",

--- a/prototypes/buildings/phadai-enclosure-mk03.lua
+++ b/prototypes/buildings/phadai-enclosure-mk03.lua
@@ -48,7 +48,8 @@ ENTITY {
     allowed_effects = {"speed", "productivity", "consumption", "pollution", "quality"},
     crafting_categories = {"phadai"},
     effect_receiver = {base_effect = {speed = -1}, speed_limits = {low = -0.9999}},
-    crafting_speed = py.farm_speed_derived(MODULE_SLOTS, "phadai-enclosure-mk01"),
+    crafting_speed = py.farm_speed_derived(MODULE_SLOTS, "phadai-enclosure-mk01") * py.farm_speed_correction20_wrong_modules(
+                            MODULE_SLOTS, "phadai-enclosure-mk01", 1, 1.5),
     energy_source = {
         type = "electric",
         usage_priority = "secondary-input",

--- a/prototypes/buildings/phadai-enclosure-mk04.lua
+++ b/prototypes/buildings/phadai-enclosure-mk04.lua
@@ -47,7 +47,8 @@ ENTITY {
     allowed_effects = {"speed", "productivity", "consumption", "pollution", "quality"},
     crafting_categories = {"phadai"},
     effect_receiver = {base_effect = {speed = -1}, speed_limits = {low = -0.9999}},
-    crafting_speed = py.farm_speed_derived(MODULE_SLOTS, "phadai-enclosure-mk01"),
+    crafting_speed = py.farm_speed_derived(MODULE_SLOTS, "phadai-enclosure-mk01") * py.farm_speed_correction20_wrong_modules(
+                            MODULE_SLOTS, "phadai-enclosure-mk01", 1, 1.75),
     energy_source = {
         type = "electric",
         usage_priority = "secondary-input",

--- a/prototypes/buildings/ralesia-plantation.lua
+++ b/prototypes/buildings/ralesia-plantation.lua
@@ -90,9 +90,9 @@ data.raw["assembling-machine"]["ralesia-plantation-mk02"].crafting_speed = py.fa
 data.raw["assembling-machine"]["ralesia-plantation-mk02"].module_slots = MODULE_SLOTS * 2
 
 data.raw["assembling-machine"]["ralesia-plantation-mk03"].effect_receiver = {base_effect = {speed = -1}, speed_limits = {low = -0.9999}}
-data.raw["assembling-machine"]["ralesia-plantation-mk03"].crafting_speed = py.farm_speed_derived(MODULE_SLOTS * 3, "ralesia-plantation-mk02")
+data.raw["assembling-machine"]["ralesia-plantation-mk03"].crafting_speed = py.farm_speed_derived(MODULE_SLOTS * 3, "ralesia-plantation-mk01")
 data.raw["assembling-machine"]["ralesia-plantation-mk03"].module_slots = MODULE_SLOTS * 3
 
 data.raw["assembling-machine"]["ralesia-plantation-mk04"].effect_receiver = {base_effect = {speed = -1}, speed_limits = {low = -0.9999}}
-data.raw["assembling-machine"]["ralesia-plantation-mk04"].crafting_speed = py.farm_speed_derived(MODULE_SLOTS * 4, "ralesia-plantation-mk03")
+data.raw["assembling-machine"]["ralesia-plantation-mk04"].crafting_speed = py.farm_speed_derived(MODULE_SLOTS * 4, "ralesia-plantation-mk01")
 data.raw["assembling-machine"]["ralesia-plantation-mk04"].module_slots = MODULE_SLOTS * 4

--- a/prototypes/buildings/trits-reef-mk02.lua
+++ b/prototypes/buildings/trits-reef-mk02.lua
@@ -50,7 +50,8 @@ ENTITY {
     allowed_effects = {"speed", "productivity", "consumption", "pollution", "quality"},
     crafting_categories = {"trits"},
     effect_receiver = {base_effect = {speed = -1}, speed_limits = {low = -0.9999}},
-    crafting_speed = py.farm_speed_derived(MODULE_SLOTS, "trits-reef-mk01"),
+    crafting_speed = py.farm_speed_derived(MODULE_SLOTS, "trits-reef-mk01") * py.farm_speed_correction20_wrong_modules(
+                            MODULE_SLOTS, "trits-reef-mk01", 1, 1.5),
     energy_source = {
         type = "electric",
         usage_priority = "secondary-input",

--- a/prototypes/buildings/trits-reef-mk03.lua
+++ b/prototypes/buildings/trits-reef-mk03.lua
@@ -48,7 +48,8 @@ ENTITY {
     allowed_effects = {"speed", "productivity", "consumption", "pollution", "quality"},
     crafting_categories = {"trits"},
     effect_receiver = {base_effect = {speed = -1}, speed_limits = {low = -0.9999}},
-    crafting_speed = py.farm_speed_derived(MODULE_SLOTS, "trits-reef-mk01"),
+    crafting_speed = py.farm_speed_derived(MODULE_SLOTS, "trits-reef-mk01") * py.farm_speed_correction20_wrong_modules(
+                            MODULE_SLOTS, "trits-reef-mk01", 1, 2),
     energy_source = {
         type = "electric",
         usage_priority = "secondary-input",

--- a/prototypes/buildings/trits-reef-mk04.lua
+++ b/prototypes/buildings/trits-reef-mk04.lua
@@ -48,7 +48,8 @@ ENTITY {
     allowed_effects = {"speed", "productivity", "consumption", "pollution", "quality"},
     crafting_categories = {"trits"},
     effect_receiver = {base_effect = {speed = -1}, speed_limits = {low = -0.9999}},
-    crafting_speed = py.farm_speed_derived(MODULE_SLOTS, "trits-reef-mk01"),
+    crafting_speed = py.farm_speed_derived(MODULE_SLOTS, "trits-reef-mk01") * py.farm_speed_correction20_wrong_modules(
+                            MODULE_SLOTS, "trits-reef-mk01", 1, 2.5),
     energy_source = {
         type = "electric",
         usage_priority = "secondary-input",

--- a/prototypes/buildings/vonix-den-mk02.lua
+++ b/prototypes/buildings/vonix-den-mk02.lua
@@ -48,7 +48,8 @@ ENTITY {
     allowed_effects = {"speed", "productivity", "consumption", "pollution", "quality"},
     crafting_categories = {"vonix"},
     effect_receiver = {base_effect = {speed = -1}, speed_limits = {low = -0.9999}},
-    crafting_speed = py.farm_speed_derived(MODULE_SLOTS, "vonix-den-mk01"),
+    crafting_speed = py.farm_speed_derived(MODULE_SLOTS, "vonix-den-mk01") * py.farm_speed_correction20_wrong_modules(
+                            MODULE_SLOTS, "vonix-den-mk01", 1, 1.5),
     energy_source = {
         type = "electric",
         usage_priority = "secondary-input",

--- a/prototypes/buildings/vonix-den-mk03.lua
+++ b/prototypes/buildings/vonix-den-mk03.lua
@@ -47,7 +47,8 @@ ENTITY {
     allowed_effects = {"speed", "productivity", "consumption", "pollution", "quality"},
     crafting_categories = {"vonix"},
     effect_receiver = {base_effect = {speed = -1}, speed_limits = {low = -0.9999}},
-    crafting_speed = py.farm_speed_derived(MODULE_SLOTS, "vonix-den-mk01"),
+    crafting_speed = py.farm_speed_derived(MODULE_SLOTS, "vonix-den-mk01") * py.farm_speed_correction20_wrong_modules(
+                            MODULE_SLOTS, "vonix-den-mk01", 1, 2),
     energy_source = {
         type = "electric",
         usage_priority = "secondary-input",

--- a/prototypes/buildings/vonix-den-mk04.lua
+++ b/prototypes/buildings/vonix-den-mk04.lua
@@ -29,7 +29,8 @@ ENTITY {
     allowed_effects = {"speed", "productivity", "consumption", "pollution", "quality"},
     crafting_categories = {"vonix"},
     effect_receiver = {base_effect = {speed = -1}, speed_limits = {low = -0.9999}},
-    crafting_speed = py.farm_speed_derived(MODULE_SLOTS, "vonix-den-mk01"),
+    crafting_speed = py.farm_speed_derived(MODULE_SLOTS, "vonix-den-mk01") * py.farm_speed_correction20_wrong_modules(
+                            MODULE_SLOTS, "vonix-den-mk01", 1, 2.5),
     energy_source = {
         type = "electric",
         usage_priority = "secondary-input",

--- a/prototypes/updates/pypetroleumhandling-updates.lua
+++ b/prototypes/updates/pypetroleumhandling-updates.lua
@@ -24,7 +24,7 @@ data.raw["assembling-machine"]["guar-gum-plantation"].crafting_speed = py.farm_s
 data.raw["assembling-machine"]["guar-gum-plantation-mk02"].effect_receiver = {base_effect = {speed = -1}, speed_limits = {low = -0.9999}}
 data.raw["assembling-machine"]["guar-gum-plantation-mk02"].module_slots = 32
 data.raw["assembling-machine"]["guar-gum-plantation-mk02"].crafting_speed = py.farm_speed_derived(32, "guar-gum-plantation")
-data.raw["assembling-machine"]["guar-gum-plantation-mk02"].effect_receiver = {base_effect = {speed = -1}, speed_limits = {low = -0.9999}}
+data.raw["assembling-machine"]["guar-gum-plantation-mk03"].effect_receiver = {base_effect = {speed = -1}, speed_limits = {low = -0.9999}}
 data.raw["assembling-machine"]["guar-gum-plantation-mk03"].module_slots = 48
 data.raw["assembling-machine"]["guar-gum-plantation-mk03"].crafting_speed = py.farm_speed_derived(48, "guar-gum-plantation")
 data.raw["assembling-machine"]["guar-gum-plantation-mk04"].effect_receiver = {base_effect = {speed = -1}, speed_limits = {low = -0.9999}}


### PR DESCRIPTION
1 of 2 PRs (other [pypostprocessing](https://github.com/pyanodon/pypostprocessing/pull/181)) to address https://github.com/pyanodon/pybugreports/issues/1525

This will restore all full farm (mkN level full of mkN modules) speeds to 2.0 speeds **except ralesias**. I thought adjusting ralesia speed was the right move, due to the nature of the typo, and the small scale of the adjustment. If you want the ralesias to match, you will find that code [here](https://github.com/pyanodon/pybugreports/issues/1525#issuecomment-4951512841)