### PR TITLE
Allow productivity on log7, log7-2 recipes so they can be turd-affected.

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -1,4 +1,9 @@
 ---------------------------------------------------------------------------------------------------
+Version: 3.1.4
+Date: ???
+  Changes:
+    - Allow productivity on log7, log7-2 recipes. Resolves https://github.com/pyanodon/pybugreports/issues/1534
+---------------------------------------------------------------------------------------------------
 Version: 3.1.3
 Date: ???
   Changes:

--- a/prototypes/updates/pyhightech-updates.lua
+++ b/prototypes/updates/pyhightech-updates.lua
@@ -381,6 +381,7 @@ RECIPE("wyrmhole"):replace_ingredient("processing-unit", "intelligent-unit"):add
 RECIPE("fungal-substrate-02"):add_ingredient {type = "item", name = "urea", amount = 3}
 RECIPE("alien-sample-03"):replace_ingredient("plastic-bar", "graphene-roll")
 RECIPE("log7-2"):add_ingredient {type = "item", name = "wood-seedling", amount = 3}:subgroup_order("py-alienlife-plants", "a"):add_unlock("wood-processing-3"):replace_category("nursery", "fwf")
+py.allow_productivity({"log7", "log7-2"})
 --RECIPE('urea'):replace_ingredient('fawogae', 'seaweed'):subgroup_order('py-alienlife-items', 'a')
 RECIPE("bonemeal2"):remove_unlock("advanced-circuit"):subgroup_order("py-alienlife-items", "a"):set_fields {hidden = true}
 RECIPE("bonemeal3"):remove_unlock("advanced-circuit"):subgroup_order("py-alienlife-items", "a"):set_fields {hidden = true}


### PR DESCRIPTION
the Internal burner TURD was not buffing the log7-2 recipe, as per https://github.com/pyanodon/pybugreports/issues/1534

I'm not sure if this fix should occur in pyAL or in pyhightech.