### PR TITLE
Enforce reproductive complex to need at least two modules to run

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -10,6 +10,7 @@ Date: ???
     - Added annotations to farming scripts and prototypes
     - Changed custom recipe UI to use pyanodons mod data
     - Localized a global variable in the caravan copy interrupt script. Resolves https://github.com/pyanodon/pybugreports/issues/1536
+    - Enforce reproductive complex to need at least two modules to run
 ---------------------------------------------------------------------------------------------------
 Version: 3.1.2
 Date: 2026-07-09

--- a/locale/de/extras.cfg
+++ b/locale/de/extras.cfg
@@ -39,5 +39,5 @@ instruction-to-deselect-spiders=__1__ und ziehen, um Kreaturen von der Auswahl z
 
 [entity-status]
 requires-module=Benötigt Modul [img=item.__1__] __2__
-requires-module-reproductive-complex=Benötigt beliebiges Tiermodul
+requires-module-reproductive-complex=Benötigt mindestens zwei Tiermodule
 requires-module-botanical-nursery=Benötigt beliebiges Pflanzenmodul

--- a/locale/en/extras.cfg
+++ b/locale/en/extras.cfg
@@ -45,5 +45,5 @@ instruction-to-deselect-spiders=__1__ and drag to remove from selected mounts.
 
 [entity-status]
 requires-module=Requires module [img=item.__1__] __2__
-requires-module-reproductive-complex=Requires any animal module
+requires-module-reproductive-complex=Requires at least two animal modules
 requires-module-botanical-nursery=Requires any plant module

--- a/locale/es-ES/extras.cfg
+++ b/locale/es-ES/extras.cfg
@@ -38,5 +38,5 @@ instruction-to-deselect-spiders=__1__ y arrastrar para eliminar de los monturas 
 
 [entity-status]
 requires-module=Requiere módulo [img=item.__1__] __2__
-requires-module-reproductive-complex=Requiere cualquier módulo animal
+requires-module-reproductive-complex=Requiere al menos dos módulos de animales
 requires-module-botanical-nursery=Requiere cualquier módulo de planta

--- a/locale/nl/extras.cfg
+++ b/locale/nl/extras.cfg
@@ -37,5 +37,5 @@ instruction-to-deselect-spiders=__1__ en sleep om te verwijderen van geselecteer
 
 [entity-status]
 requires-module=Vereist module [img=item.__1__] __2__
-requires-module-reproductive-complex=Vereist enige dierenmodule
+requires-module-reproductive-complex=Vereist ten minste twee dierenmodules
 requires-module-botanical-nursery=Vereist enige dierenmodule

--- a/locale/pl/extras.cfg
+++ b/locale/pl/extras.cfg
@@ -37,5 +37,5 @@ instruction-to-deselect-spiders=__1__ i przeciągnij, aby usunąć z wybranych w
 
 [entity-status]
 requires-module=Wymaga modułu [img=item.__1__] __2__
-requires-module-reproductive-complex=Wymaga dowolnego modułu zwierzęcego
+requires-module-reproductive-complex=Wymaga co najmniej dwóch modułów zwierzęcych
 requires-module-botanical-nursery=Wymaga dowolnego modułu roślinnego

--- a/locale/ru/extras.cfg
+++ b/locale/ru/extras.cfg
@@ -37,5 +37,5 @@ instruction-to-deselect-spiders=__1__ и перетащите для удале�
 
 [entity-status]
 requires-module=Требуется модуль [img=item.__1__] __2__
-requires-module-reproductive-complex=Требуется модуль любого животного
+requires-module-reproductive-complex=Требуется как минимум два модуля животных
 requires-module-botanical-nursery=Требуется модуль любого растения

--- a/locale/uk/extras.cfg
+++ b/locale/uk/extras.cfg
@@ -37,5 +37,5 @@ instruction-to-deselect-spiders=__1__ і перетягніть, щоб вида
 
 [entity-status]
 requires-module=Потрібен модуль [img=item.__1__] __2__
-requires-module-reproductive-complex=Потрібен будь-який тваринний модуль
+requires-module-reproductive-complex=Потрібно щонайменше два модулі тварин
 requires-module-botanical-nursery=Потрібен будь-який рослинний модуль

--- a/scripts/farming/farming.lua
+++ b/scripts/farming/farming.lua
@@ -23,7 +23,9 @@ function Farming.process(farm_data)
     local entity = farm_data.entity
     local kingdom = Farming.get_kingdom(entity)
     if not kingdom then return end
-    if entity.get_module_inventory().is_empty() then
+    local is_rc = not not entity.name:find("^rc%-mk")
+    local module_inv = entity.get_module_inventory()
+    if not module_inv or module_inv.get_item_count() < (is_rc and 2 or 1) then
         -- update render, otherwise it will destroy itself
         -- it lasts just longer than once cycle so it will always stick around even when timing and ordering gets weird
         local default_module = Farming.get_default_module(entity)
@@ -33,9 +35,11 @@ function Farming.process(farm_data)
             diode = defines.entity_status_diode.red,
             label = message
         }
+        if is_rc then entity.disabled_by_script = true end
     else
         py.clear_alert(farm_data.alert_id)
         entity.custom_status = nil
+        if is_rc then entity.disabled_by_script = false end
     end
 end
 


### PR DESCRIPTION
I discovered that AL creatures in the reproductive complex are able to multiply themselves without the need of modules. This feels cheesy and removes the need to breed initial creatures in the creature chamber.

With this fix I aim to enforce two or more modules to be present in the reproductive complex for it to work.

Translations other than English and German have been added with the use of AI.
Will remove AI generated translation strings if requested.