### PR TITLE
Fix crash with Factory Planner <=2.1.12

### DIFF
--- a/scripts/turd/turd.lua
+++ b/scripts/turd/turd.lua
@@ -568,7 +568,9 @@ end
 
 -- Tells FP the named interface went stale, prompting it to pull again
 local function notify_factory_planner(integration)
-    if not remote.interfaces["fp-integration"] then return end
+    -- FP versions before TURD support register the interface without this function
+    local interface = remote.interfaces["fp-integration"]
+    if not (interface and interface.invalidate) then return end
     remote.call("fp-integration", "invalidate", {version = 1, integration = integration})
 end
 


### PR DESCRIPTION
Really sorry about this, but due to an oversight on my part, the game will crash when loading into Py with the most recent release and FP active. It's due to older versions of FP not providing an interface which my implementation in Py calls unconditionally. So this fix is necessary because I obviously can't fix any past releases of my mod to avoid it. Any current/future releases would be fine but yeah doesn't help much.