### PR TITLE
 [FIX] pre-3.1.3 digosaurs do not find their parent and go idle because of missing migration

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -1,4 +1,9 @@
 ---------------------------------------------------------------------------------------------------
+Version: 3.1.5
+Date: 2026-08-29
+  Changes:
+    - Fixed digosaurus dig sites gradually stopping after a save was updated across 3.1.3 (the parent -> parent_id rename shipped without a migration); existing sites now recover on load instead of needing to be re-placed
+---------------------------------------------------------------------------------------------------
 Version: 3.1.4
 Date: 2026-08-28
   Changes:

--- a/info.json
+++ b/info.json
@@ -1,6 +1,6 @@
 {
     "name": "pyalienlife",
-    "version": "3.1.4",
+    "version": "3.1.5",
     "factorio_version": "2.1",
     "title": "Pyanodons AlienLife",
     "author": "Pyanodon, Nexela, Kingarthur, notnotmelon, Mootykins, ShadowGlass, Archezekiel, Quintuple, przemo1232, protocol_1903",

--- a/migrations/digosaurus-parent-id.lua
+++ b/migrations/digosaurus-parent-id.lua
@@ -1,0 +1,20 @@
+-- Starting in 3.1.3, old digosaurs are missing their parent_id field, so they will never be able to find their dig site again.
+-- This migration clears out all active digosaurs and their proxies, so that the dig sites can be refilled with new digosaurs that have the correct parent_id field.
+
+storage.dig_sites = storage.dig_sites or {}
+
+for _, dig_site in pairs(storage.dig_sites) do
+    for _, digosaur_data in pairs(dig_site.active_digosaurs or {}) do
+        if digosaur_data.proxy and digosaur_data.proxy.valid then
+            digosaur_data.proxy.destroy()
+        end
+
+        if digosaur_data.entity and digosaur_data.entity.valid then
+            digosaur_data.entity.destroy()
+        end
+    end
+
+    dig_site.active_digosaurs = {}
+end
+
+storage.digosaurs = {}


### PR DESCRIPTION
Hello,

I noticed this issue when upgrading to the latest version of Pyalien life.

I looked into the code change and saw `parent` got renamed to `parent_id`. This seems to cause the digosaurs to go idle when checking for `parent_id` in digosaurus.lua since the pre-3.1.3 digosaurs do not have a `parent_id` and no migration was written.

Sorry about the version bump: I had to bump it to try it out on my save but feel free to not bump it now if you'd rather not (ofc).